### PR TITLE
Improve optimizations (fixes #45)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,9 +3,19 @@
   "plugins": [
     "add-module-exports",
     "dev-expression",
-    "transform-runtime",
-    "transform-node-env-inline",
-    "transform-react-constant-elements",
-    "transform-react-inline-elements"
-  ]
+    "transform-runtime"
+  ],
+  "env": {
+    "production": {
+      "plugins": [
+        "add-module-exports",
+        "dev-expression",
+        "transform-runtime",
+        "transform-node-env-inline",
+        "transform-react-constant-elements",
+        "transform-react-remove-prop-types",
+        "transform-react-pure-class-to-function"
+      ]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "unit": "mocha --compilers js:babel-register -r jsdom-global/register src/**/test.js",
     "test": "npm run unit",
     "pretest": "npm run lint",
-    "build": "babel src --only index.js --out-dir components",
+    "build": "NODE_ENV=production babel src --only index.js --out-dir components",
     "prepublish": "npm run clean && npm test && npm run build"
   },
   "repository": {
@@ -37,7 +37,8 @@
     "babel-plugin-dev-expression": "^0.2.1",
     "babel-plugin-transform-node-env-inline": "^6.5.0",
     "babel-plugin-transform-react-constant-elements": "^6.5.0",
-    "babel-plugin-transform-react-inline-elements": "^6.6.5",
+    "babel-plugin-transform-react-pure-class-to-function": "^1.0.1",
+    "babel-plugin-transform-react-remove-prop-types": "^0.2.7",
     "babel-plugin-transform-runtime": "^6.7.5",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",


### PR DESCRIPTION
- 1. Didn't find anything better for the IE fix than to remove `transform-react-inline-elements`.
- 2. Added the production environment for Babel.

> This transform should be enabled only in production (e.g., just before minifying your code) because although it improves runtime performance, it makes warning messages more cryptic.
- 3. Several additional optimizations (https://github.com/thejameskyle/babel-react-optimize)
