### PR TITLE
Link, Button: Impossible to do a default prevention in onClick handler

### DIFF
--- a/src/Button/examples.js
+++ b/src/Button/examples.js
@@ -38,7 +38,7 @@ class Example extends React.Component {
                     </div>
 
                     <div className="example">
-                        <Button size="l" type="link" url="https://yandex.ru">Link</Button>
+                        <Button size="l" type="link" url="https://yandex.ru" onClick={this.onLinkClick}>Link</Button>
                     </div>
 
                     <div className="example">
@@ -55,6 +55,10 @@ class Example extends React.Component {
         this.setState({
             clicks: this.state.clicks + 1,
         });
+    }
+
+    onLinkClick(e) {
+        e.preventDefault();
     }
 }
 

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -93,12 +93,6 @@ class Button extends Control {
 
         return className;
     }
-
-    /** @override */
-    // onMouseDown(e) {
-    //     e.preventDefault(); // NOTE: prevents button from being blurred at least in FF and Safari
-    //     super.onMouseDown(e);
-    // }
 }
 
 Button.propTypes = {

--- a/src/Button/test.js
+++ b/src/Button/test.js
@@ -229,8 +229,12 @@ describe('Button', () => {
     describe('click', () => {
         it('reacts on click', () => {
             const spy = sinon.spy();
+            const onClickHandler = event => {
+                expect(event.type).to.equal('click');
+                spy();
+            };
             const button = shallow(
-                <Button onClick={spy}>button</Button>
+                <Button onClick={onClickHandler}>button</Button>
             );
 
             button

--- a/src/Button/test.js
+++ b/src/Button/test.js
@@ -142,11 +142,11 @@ describe('Button', () => {
         it('is pressed on mousedown/mouseup', () => {
             const button = shallow(<Button>button</Button>);
 
-            button.simulate('mousedown');
+            simulateEvent(button, 'mousedown', { button: 0 });
             expect(button).to.have.state('pressed', true);
             expect(button).to.have.className('button_pressed');
 
-            button.simulate('mouseup');
+            simulateEvent(button, 'mouseup', { button: 0 });
             expect(button).to.have.state('pressed', false);
             expect(button).to.not.have.className('button_pressed');
         });
@@ -156,31 +156,31 @@ describe('Button', () => {
 
             expect(button.state('pressed')).to.not.be.ok;
 
-            button.simulate('keydown', { key: 'q' });
+            simulateEvent(button, 'keydown', { key: 'q' });
             expect(button.state('pressed')).to.not.be.ok;
-            button.simulate('keyup');
+            simulateEvent(button, 'keyup');
 
-            button.simulate('keydown', { key: ' ' });
+            simulateEvent(button, 'keydown', { key: ' ' });
             expect(button.state('pressed')).to.be.true;
-            button.simulate('keyup');
+            simulateEvent(button, 'keyup');
             expect(button.state('pressed')).to.not.be.ok;
 
-            button.simulate('keydown', { key: 'Enter' });
+            simulateEvent(button, 'keydown', { key: 'Enter' });
             expect(button.state('pressed')).to.be.true;
-            button.simulate('keyup');
+            simulateEvent(button, 'keyup');
             expect(button.state('pressed')).to.not.be.ok;
         });
 
         it('can not be pressed if disabled', () => {
             const button = shallow(<Button disabled>button</Button>);
 
-            button.simulate('mousedown');
+            simulateEvent(button, 'mousedown');
             expect(button.state('pressed')).to.not.be.ok;
 
-            button.simulate('keydown', { key: ' ' });
+            simulateEvent(button, 'keydown', { key: ' ' });
             expect(button.state('pressed')).to.not.be.ok;
 
-            button.simulate('keydown', { key: 'Enter' });
+            simulateEvent(button, 'keydown', { key: 'Enter' });
             expect(button.state('pressed')).to.not.be.ok;
         });
 
@@ -191,11 +191,11 @@ describe('Button', () => {
                 <Button focused onKeyDown={spy1} onKeyUp={spy2}>button</Button>
             );
 
-            button.simulate('keydown', { key: 'LeftArrow' });
+            simulateEvent(button, 'keydown', { key: 'LeftArrow' });
             expect(spy1.calledOnce).to.be.true;
             expect(spy1.calledWithMatch({ key: 'LeftArrow' })).to.be.true;
 
-            button.simulate('keyup', { key: 'LeftArrow' });
+            simulateEvent(button, 'keyup', { key: 'LeftArrow' });
             expect(spy2.calledOnce).to.be.true;
             expect(spy2.calledWithMatch({ key: 'LeftArrow' })).to.be.true;
         });
@@ -207,10 +207,10 @@ describe('Button', () => {
                 <Button disabled onKeyDown={spy1} onKeyUp={spy2}>button</Button>
             );
 
-            button.simulate('keydown', { key: 'LeftArrow' });
+            simulateEvent(button, 'keydown', { key: 'LeftArrow' });
             expect(spy1.called).to.be.false;
 
-            button.simulate('keyup', { key: 'LeftArrow' });
+            simulateEvent(button, 'keyup', { key: 'LeftArrow' });
             expect(spy2.called).to.be.false;
         });
 
@@ -220,14 +220,14 @@ describe('Button', () => {
                 <Button onKeyPress={spy}>button</Button>
             );
 
-            button.simulate('keypress', { key: 'q' });
+            simulateEvent(button, 'keypress', { key: 'q' });
             expect(spy.calledOnce).to.be.true;
             expect(spy.calledWithMatch({ key: 'q' })).to.be.true;
         });
     });
 
     describe('click', () => {
-        it('reacts on click', () => {
+        it('reacts on left button click', () => {
             const spy = sinon.spy();
             const onClickHandler = event => {
                 expect(event.type).to.equal('click');
@@ -237,11 +237,22 @@ describe('Button', () => {
                 <Button onClick={onClickHandler}>button</Button>
             );
 
-            button
-                .simulate('mousedown')
-                .simulate('mouseup');
+            simulateEvent(button, 'mousedown', { button: 0 });
+            simulateEvent(button, 'mouseup');
 
             expect(spy.calledOnce).to.be.true;
+        });
+
+        it('does not reacts if clicked by button other than left', () => {
+            const spy = sinon.spy();
+            const button = shallow(
+                <Button onClick={spy}>button</Button>
+            );
+
+            simulateEvent(button, 'mousedown', { button: 1 });
+            simulateEvent(button, 'mouseup');
+
+            expect(spy.called).to.not.be.true;
         });
 
         it('reacts on keypress by enter or space', () => {
@@ -250,11 +261,13 @@ describe('Button', () => {
                 <Button onClick={spy} focused>button</Button>
             );
 
-            button
-                .simulate('keydown', { key: 'Enter' })
-                .simulate('keyup')
-                .simulate('keydown', { key: ' ' })
-                .simulate('keyup');
+            simulateEvent(button, 'keydown', { key: 'Enter' });
+            simulateEvent(button, 'keyup');
+
+            expect(spy.calledOnce).to.be.true;
+
+            simulateEvent(button, 'keydown', { key: ' ' });
+            simulateEvent(button, 'keyup');
 
             expect(spy.calledTwice).to.be.true;
         });
@@ -265,11 +278,20 @@ describe('Button', () => {
                 <Button disabled onClick={spy}>button</Button>
             );
 
-            button
-                .simulate('mousedown')
-                .simulate('mouseup');
+            simulateEvent(button, 'mousedown', { button: 0 });
+            simulateEvent(button, 'mouseup');
 
             expect(spy.called).to.be.false;
         });
     });
 });
+
+const simulateEvent = (target, type, args) => {
+    const eventData = {
+        type,
+        isDefaultPrevented() {},
+        preventDefault() {},
+        ...args,
+    };
+    target.simulate(type, eventData);
+};

--- a/src/Checkbox/test.js
+++ b/src/Checkbox/test.js
@@ -233,11 +233,11 @@ describe('Checkbox', () => {
 
             expect(checkbox.state('checked')).to.not.be.ok;
 
-            checkbox.find('button').simulate('mousedown');
+            checkbox.find('button').simulate('mousedown', { button: 0 });
             checkbox.find('button').simulate('mouseup');
             expect(checkbox.state('checked')).to.be.true;
 
-            checkbox.find('button').simulate('mousedown');
+            checkbox.find('button').simulate('mousedown', { button: 0 });
             checkbox.find('button').simulate('mouseup');
             expect(checkbox.state('checked')).to.be.false;
 
@@ -250,7 +250,7 @@ describe('Checkbox', () => {
             const spy = sinon.spy();
             const checkbox = mount(<Checkbox type="button" onCheck={spy} name="foo" bar="42">checkbox</Checkbox>);
 
-            checkbox.find('button').simulate('mousedown');
+            checkbox.find('button').simulate('mousedown', { button: 0 });
             checkbox.find('button').simulate('mouseup');
 
             expect(spy.getCall(0).args[1].name).to.equal('foo');
@@ -261,7 +261,7 @@ describe('Checkbox', () => {
             const spy = sinon.spy();
             const checkbox = mount(<Checkbox type="button" disabled onCheck={spy}>checkbox</Checkbox>);
 
-            checkbox.find('button').simulate('mousedown');
+            checkbox.find('button').simulate('mousedown', { button: 0 });
             checkbox.find('button').simulate('mouseup');
             expect(checkbox.state('checked')).to.not.be.ok;
 

--- a/src/CheckboxGroup/test.js
+++ b/src/CheckboxGroup/test.js
@@ -162,7 +162,7 @@ describe('CheckboxGroup', () => {
                 .find('.checkbox')
                 .at(1)
                 .find('button');
-            secondCheckboxButton.simulate('mousedown');
+            secondCheckboxButton.simulate('mousedown', { button: 0 });
             secondCheckboxButton.simulate('mouseup');
 
             expect(wrapper.state('value')).to.be.eql(['10', '30', '20']);
@@ -326,7 +326,7 @@ describe('CheckboxGroup', () => {
                 .find('.checkbox')
                 .at(1)
                 .find('button');
-            secondCheckboxButton.simulate('mousedown');
+            secondCheckboxButton.simulate('mousedown', { button: 0 });
             secondCheckboxButton.simulate('mouseup');
 
             expect(wrapper.state('value')).to.be.eql(['10', '30', '20']);

--- a/src/Link/examples.js
+++ b/src/Link/examples.js
@@ -36,7 +36,7 @@ class Example extends React.Component {
         );
     }
 
-    onClick(e) {
+    onClick() {
         this.setState({
             clicks: this.state.clicks + 1,
         });

--- a/src/Link/examples.js
+++ b/src/Link/examples.js
@@ -4,7 +4,6 @@ import App from '../App';
 import Link from './index.js';
 
 class Example extends React.Component {
-
     constructor(props) {
         super(props);
 
@@ -20,7 +19,7 @@ class Example extends React.Component {
             <App theme="islands">
                 <div className="examples">
                     <div className="example">
-                        <Link size="l" url="#/Yandex">Yandex</Link>
+                        <Link size="l" url="#/Yandex" onClick={this.onLinkClick}>Yandex</Link>
                     </div>
 
                     <div className="example">
@@ -28,7 +27,7 @@ class Example extends React.Component {
                     </div>
 
                     <div className="example">
-                        <Link size="l" onClick={this.onClick} disabled>Google</Link>
+                        <Link size="l" onClick={this.onClick} disabled>Google (disabled)</Link>
                     </div>
 
                     <p>Clicks: {this.state.clicks}</p>
@@ -37,10 +36,14 @@ class Example extends React.Component {
         );
     }
 
-    onClick() {
+    onClick(e) {
         this.setState({
             clicks: this.state.clicks + 1,
         });
+    }
+
+    onLinkClick(e) {
+        e.preventDefault();
     }
 }
 

--- a/src/Link/index.js
+++ b/src/Link/index.js
@@ -52,7 +52,6 @@ class Link extends Control {
 
         return className;
     }
-
 }
 
 Link.propTypes = {

--- a/src/Link/test.js
+++ b/src/Link/test.js
@@ -212,7 +212,11 @@ describe('Link', () => {
     describe('click', () => {
         it('reacts on click', () => {
             const spy = sinon.spy();
-            const link = shallow(<Link onClick={spy}>button</Link>);
+            const onClickHandler = event => {
+                expect(event.type).to.equal('click');
+                spy();
+            };
+            const link = shallow(<Link onClick={onClickHandler}>button</Link>);
 
             link
                 .simulate('mousedown')

--- a/src/Link/test.js
+++ b/src/Link/test.js
@@ -129,10 +129,10 @@ describe('Link', () => {
         it('is pressed on mousedown/mouseup', () => {
             const link = shallow(<Link url="http://yandex.ru">link</Link>);
 
-            link.simulate('mousedown');
+            simulateEvent(link, 'mousedown', { button: 0 });
             expect(link).to.have.state('pressed', true);
 
-            link.simulate('mouseup');
+            simulateEvent(link, 'mouseup', { button: 0 });
             expect(link).to.have.state('pressed', false);
         });
 
@@ -141,31 +141,31 @@ describe('Link', () => {
 
             expect(link.state('pressed')).to.not.be.ok;
 
-            link.simulate('keydown', { key: 'q' });
+            simulateEvent(link, 'keydown', { key: 'q' });
             expect(link.state('pressed')).to.not.be.ok;
-            link.simulate('keyup');
+            simulateEvent(link, 'keyup');
 
-            link.simulate('keydown', { key: ' ' });
+            simulateEvent(link, 'keydown', { key: ' ' });
             expect(link.state('pressed')).to.be.true;
-            link.simulate('keyup');
+            simulateEvent(link, 'keyup');
             expect(link.state('pressed')).to.not.be.ok;
 
-            link.simulate('keydown', { key: 'Enter' });
+            simulateEvent(link, 'keydown', { key: 'Enter' });
             expect(link.state('pressed')).to.be.true;
-            link.simulate('keyup');
+            simulateEvent(link, 'keyup');
             expect(link.state('pressed')).to.not.be.ok;
         });
 
         it('can not be pressed if disabled', () => {
             const link = shallow(<Link url="http://yandex.ru" disabled>link</Link>);
 
-            link.simulate('mousedown');
+            simulateEvent(link, 'mousedown', { button: 0 });
             expect(link.state('pressed')).to.not.be.ok;
 
-            link.simulate('keydown', { key: ' ' });
+            simulateEvent(link, 'keydown', { key: ' ' });
             expect(link.state('pressed')).to.not.be.ok;
 
-            link.simulate('keydown', { key: 'Enter' });
+            simulateEvent(link, 'keydown', { key: 'Enter' });
             expect(link.state('pressed')).to.not.be.ok;
         });
 
@@ -176,11 +176,11 @@ describe('Link', () => {
                 <Link focused onKeyDown={spy1} onKeyUp={spy2}>link</Link>
             );
 
-            link.simulate('keydown', { key: 'LeftArrow' });
+            simulateEvent(link, 'keydown', { key: 'LeftArrow' });
             expect(spy1.calledOnce).to.be.true;
             expect(spy1.calledWithMatch({ key: 'LeftArrow' })).to.be.true;
 
-            link.simulate('keyup', { key: 'LeftArrow' });
+            simulateEvent(link, 'keyup', { key: 'LeftArrow' });
             expect(spy2.calledOnce).to.be.true;
             expect(spy2.calledWithMatch({ key: 'LeftArrow' })).to.be.true;
         });
@@ -192,10 +192,10 @@ describe('Link', () => {
                 <Link disabled onKeyDown={spy1} onKeyUp={spy2}>link</Link>
             );
 
-            link.simulate('keydown', { key: 'LeftArrow' });
+            simulateEvent(link, 'keydown', { key: 'LeftArrow' });
             expect(spy1.called).to.be.false;
 
-            link.simulate('keyup', { key: 'LeftArrow' });
+            simulateEvent(link, 'keyup', { key: 'LeftArrow' });
             expect(spy2.called).to.be.false;
         });
 
@@ -203,14 +203,14 @@ describe('Link', () => {
             const spy = sinon.spy();
             const link = shallow(<Link onKeyPress={spy}>link</Link>);
 
-            link.simulate('keypress', { key: 'q' });
+            simulateEvent(link, 'keypress', { key: 'q' });
             expect(spy.calledOnce).to.be.true;
             expect(spy.calledWithMatch({ key: 'q' })).to.be.true;
         });
     });
 
     describe('click', () => {
-        it('reacts on click', () => {
+        it('reacts on left button click', () => {
             const spy = sinon.spy();
             const onClickHandler = event => {
                 expect(event.type).to.equal('click');
@@ -218,22 +218,33 @@ describe('Link', () => {
             };
             const link = shallow(<Link onClick={onClickHandler}>button</Link>);
 
-            link
-                .simulate('mousedown')
-                .simulate('mouseup');
+            simulateEvent(link, 'mousedown', { button: 0 });
+            simulateEvent(link, 'mouseup');
 
             expect(spy.calledOnce).to.be.true;
+        });
+
+        it('does not reacts if clicked by button other than left', () => {
+            const spy = sinon.spy();
+            const link = shallow(<Link onClick={spy}>button</Link>);
+
+            simulateEvent(link, 'mousedown', { button: 1 });
+            simulateEvent(link, 'mouseup');
+
+            expect(spy.called).to.not.be.true;
         });
 
         it('reacts on keypress by enter or space', () => {
             const spy = sinon.spy();
             const link = shallow(<Link onClick={spy} focused>button</Link>);
 
-            link
-                .simulate('keydown', { key: 'Enter' })
-                .simulate('keyup')
-                .simulate('keydown', { key: ' ' })
-                .simulate('keyup');
+            simulateEvent(link, 'keydown', { key: 'Enter' });
+            simulateEvent(link, 'keyup');
+
+            expect(spy.calledOnce).to.be.true;
+
+            simulateEvent(link, 'keydown', { key: ' ' });
+            simulateEvent(link, 'keyup');
 
             expect(spy.calledTwice).to.be.true;
         });
@@ -242,11 +253,20 @@ describe('Link', () => {
             const spy = sinon.spy();
             const link = shallow(<Link disabled onClick={spy}>button</Link>);
 
-            link
-                .simulate('mousedown')
-                .simulate('mouseup');
+            simulateEvent(link, 'mousedown', { button: 0 });
+            simulateEvent(link, 'mouseup');
 
             expect(spy.called).to.be.false;
         });
     });
 });
+
+const simulateEvent = (target, type, args) => {
+    const eventData = {
+        type,
+        isDefaultPrevented() {},
+        preventDefault() {},
+        ...args,
+    };
+    target.simulate(type, eventData);
+};

--- a/src/Radio/test.js
+++ b/src/Radio/test.js
@@ -247,15 +247,15 @@ describe('Radio', () => {
 
             expect(radio.state('checked')).to.not.be.ok;
 
-            radio.find('button').simulate('mousedown');
+            radio.find('button').simulate('mousedown', { button: 0 });
             radio.find('button').simulate('mouseup');
             expect(radio.state('checked')).to.be.true;
 
-            radio.find('button').simulate('mousedown');
+            radio.find('button').simulate('mousedown', { button: 0 });
             radio.find('button').simulate('mouseup');
             expect(radio.state('checked')).to.be.true;
 
-            expect(spy.callCount).to.equal(1);
+            expect(spy.calledOnce).to.be.true;
             expect(spy.getCall(0).args[0]).to.be.true;
         });
 
@@ -263,7 +263,7 @@ describe('Radio', () => {
             const spy = sinon.spy();
             const radio = mount(<Radio type="button" onCheck={spy} name="foo" bar="42">radio</Radio>);
 
-            radio.find('button').simulate('mousedown');
+            radio.find('button').simulate('mousedown', { button: 0 });
             radio.find('button').simulate('mouseup');
 
             expect(spy.getCall(0).args[1].name).to.equal('foo');

--- a/src/RadioGroup/test.js
+++ b/src/RadioGroup/test.js
@@ -162,7 +162,7 @@ describe('RadioGroup', () => {
                 .find('.radio')
                 .at(1)
                 .find('button');
-            secondRadioButton.simulate('mousedown');
+            secondRadioButton.simulate('mousedown', { button: 0 });
             secondRadioButton.simulate('mouseup');
 
             expect(wrapper.state('value')).to.equal('20');
@@ -326,7 +326,7 @@ describe('RadioGroup', () => {
                 .find('.radio')
                 .at(1)
                 .find('button');
-            secondRadioButton.simulate('mousedown');
+            secondRadioButton.simulate('mousedown', { button: 0 });
             secondRadioButton.simulate('mouseup');
 
             expect(wrapper.state('value')).to.equal('20');

--- a/src/pressable/index.js
+++ b/src/pressable/index.js
@@ -10,7 +10,7 @@ const pressable = BaseComponent => class extends BaseComponent {
             pressed: false,
         };
 
-        this.shouldPreventDefaultClick = false;
+        this.shouldPrevenDefaultClick = false;
 
         this.onMouseUp = this.onMouseUp.bind(this);
         this.onMouseDown = this.onMouseDown.bind(this);
@@ -43,7 +43,7 @@ const pressable = BaseComponent => class extends BaseComponent {
 
     dispatchClick(e) {
         if (this.props.onClick) {
-            this.shouldPreventDefaultClick = false;
+            this.shouldPrevenDefaultClick = false;
 
             const eventType = e.type;
 
@@ -52,7 +52,7 @@ const pressable = BaseComponent => class extends BaseComponent {
             e.type = eventType;
 
             if (e.isDefaultPrevented()) {
-                this.shouldPreventDefaultClick = true;
+                this.shouldPrevenDefaultClick = true;
             }
         }
     }
@@ -122,7 +122,7 @@ const pressable = BaseComponent => class extends BaseComponent {
 
     /** @override */
     onClick(e) {
-        if (this.shouldPreventDefaultClick) {
+        if (this.shouldPrevenDefaultClick) {
             e.preventDefault();
         }
         if (super.onClick) {

--- a/src/pressable/index.js
+++ b/src/pressable/index.js
@@ -10,10 +10,13 @@ const pressable = BaseComponent => class extends BaseComponent {
             pressed: false,
         };
 
+        this.shouldPreventDefaultClick = false;
+
         this.onMouseUp = this.onMouseUp.bind(this);
         this.onMouseDown = this.onMouseDown.bind(this);
         this.onKeyUp = this.onKeyUp.bind(this);
         this.onKeyDown = this.onKeyDown.bind(this);
+        this.onClick = this.onClick.bind(this);
     }
 
     /** @override */
@@ -29,6 +32,7 @@ const pressable = BaseComponent => class extends BaseComponent {
     getControlHandlers() {
         return {
             ...super.getControlHandlers(),
+            onClick: this.onClick,
             onMouseDown: this.onMouseDown,
             onMouseUp: this.onMouseUp,
             onKeyUp: this.onKeyUp,
@@ -37,38 +41,54 @@ const pressable = BaseComponent => class extends BaseComponent {
         };
     }
 
-    dispatchClick() {
+    dispatchClick(e) {
         if (this.props.onClick) {
-            this.props.onClick(this.props);
+            this.shouldPreventDefaultClick = false;
+
+            const eventType = e.type;
+
+            e.type = 'click';
+            this.props.onClick(e, this.props);
+            e.type = eventType;
+
+            if (e.isDefaultPrevented()) {
+                this.shouldPreventDefaultClick = true;
+            }
         }
     }
 
     /** @override */
     onMouseLeave() {
-        super.onMouseLeave();
+        if (super.onMouseLeave) {
+            super.onMouseLeave();
+        }
         this.setState({ pressed: false });
     }
 
     /** @override */
     onMouseDown(e) {
-        super.onMouseDown(e);
-        if (!this.props.disabled) {
+        if (super.onMouseDown) {
+            super.onMouseDown(e);
+        }
+        if (!this.props.disabled && e.button === 0) {
             this.setState({ pressed: true });
         }
     }
 
     /** @override */
     onMouseUp(e) {
-        super.onMouseUp(e);
+        if (super.onMouseUp) {
+            super.onMouseUp(e);
+        }
         if (this.state.pressed) {
             this.setState({ pressed: false });
-            this.dispatchClick();
+            this.dispatchClick(e);
         }
     }
 
     /** @override */
     onFocus() {
-        if (!this.state.pressed) {
+        if (!this.state.pressed && super.onFocus) {
             super.onFocus();
         }
     }
@@ -93,11 +113,20 @@ const pressable = BaseComponent => class extends BaseComponent {
         }
         if (this.state.pressed) {
             this.setState({ pressed: false });
-            this.dispatchClick();
-
+            this.dispatchClick(e);
         }
         if (this.props.onKeyUp) {
             this.props.onKeyUp(e, this.props);
+        }
+    }
+
+    /** @override */
+    onClick(e) {
+        if (this.shouldPreventDefaultClick) {
+            e.preventDefault();
+        }
+        if (super.onClick) {
+            super.onClick(e);
         }
     }
 };


### PR DESCRIPTION
fix #60 
- call `onClick` handler only on the left-button
- pass event (type=click) object to `onClick` handler
- make `pressable` more genreric
