### PR TITLE
Checkbox, CheckboxGroup: make components stateless

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "browserify": "^13.0.0",
     "browserify-global-shim": "^1.0.3",
     "chai": "^3.5.0",
-    "chai-enzyme": "^0.4.2",
+    "chai-enzyme": "^0.5.0",
     "cheerio": "^0.20.0",
     "enzyme": "^2.2.0",
     "eslint": "^2.8.0",
@@ -75,6 +75,7 @@
     "react-addons-test-utils": "^15.0.1",
     "react-dom": "^15.0.2",
     "sinon": "^1.17.3",
+    "sinon-chai": "^2.8.0",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.7.0"
   }

--- a/src/Checkbox/examples.js
+++ b/src/Checkbox/examples.js
@@ -1,0 +1,40 @@
+import React, { Component } from 'react';
+import App from '../App';
+import Checkbox from './';
+
+class CheckboxExample extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            checked: false,
+        };
+    }
+
+    render() {
+        return (
+            <div className="example">
+                <Checkbox theme="islands" size="m" name="c1"
+                    {...this.props}
+                    checked={this.state.checked}
+                    onCheck={checked => this.onCheck(checked)}
+                />
+            </div>
+        );
+    }
+
+    onCheck(checked) {
+        this.setState({ checked });
+    }
+}
+
+export default function Example() {
+    return (
+        <App theme="islands">
+            <div className="examples">
+                <CheckboxExample />
+                <CheckboxExample type="button">Push me!</CheckboxExample>
+            </div>
+        </App>
+    );
+}

--- a/src/Checkbox/test.js
+++ b/src/Checkbox/test.js
@@ -1,24 +1,26 @@
 /* eslint-env mocha */
 
 import React from 'react';
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
+import chaiEnzyme from 'chai-enzyme';
 import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
-
+import sinonChai from 'sinon-chai';
 import Checkbox from './';
 
+chai.use(sinonChai);
+chai.use(chaiEnzyme());
+
 describe('Checkbox', () => {
-
-    describe('type="button"', () => {
-
+    describe('no type (type=checkbox)', () => {
         it('is a checkbox', () => {
-            const checkbox = shallow(<Checkbox type="button">checkbox</Checkbox>);
+            const checkbox = shallow(<Checkbox>checkbox</Checkbox>);
 
             expect(checkbox.is('.checkbox')).to.be.true;
         });
 
         it('has label', () => {
-            const checkbox = mount(<Checkbox type="button">checkbox</Checkbox>);
+            const checkbox = mount(<Checkbox>checkbox</Checkbox>);
 
             const label = checkbox.find('label');
             expect(label.length).to.equal(1);
@@ -26,7 +28,7 @@ describe('Checkbox', () => {
         });
 
         it('has input', () => {
-            const checkbox = mount(<Checkbox type="button">checkbox</Checkbox>);
+            const checkbox = mount(<Checkbox>checkbox</Checkbox>);
 
             const input = checkbox.find('input');
             expect(input.length).to.equal(1);
@@ -34,7 +36,156 @@ describe('Checkbox', () => {
             expect(input.node.getAttribute('type')).to.equal('checkbox');
         });
 
-        it('has button', () => {
+        it('has text', () => {
+            const checkbox = mount(<Checkbox>checkbox</Checkbox>);
+
+            const text = checkbox.find('span.checkbox__text');
+            expect(text.length).to.equal(1);
+            expect(text.node.textContent).to.equal('checkbox');
+        });
+
+        it('accepts type prop', () => {
+            const checkbox = mount(<Checkbox type="foo"/>);
+
+            expect(checkbox.find('label').hasClass('checkbox_type_foo')).to.be.true;
+        });
+
+        it('accepts name prop', () => {
+            const checkbox = mount(<Checkbox name="foo">checkbox</Checkbox>);
+
+            expect(checkbox.find('input').node.getAttribute('name')).to.equal('foo');
+        });
+
+        it('accepts value prop', () => {
+            const checkbox = mount(<Checkbox value="foo">checkbox</Checkbox>);
+
+            expect(checkbox.find('input').node.value).to.equal('foo');
+        });
+
+        it('accepts theme prop', () => {
+            const checkbox = mount(<Checkbox theme="foo">checkbox</Checkbox>);
+
+            expect(checkbox.find('label').hasClass('checkbox_theme_foo')).to.be.true;
+        });
+
+        it('accepts size prop', () => {
+            const checkbox = mount(<Checkbox size="foo">checkbox</Checkbox>);
+
+            expect(checkbox.find('label').hasClass('checkbox_size_foo')).to.be.true;
+        });
+
+        it('accepts className prop', () => {
+            const checkbox = shallow(<Checkbox className="my-checkbox not-my-checkbox">checkbox</Checkbox>);
+
+            expect(checkbox.hasClass('my-checkbox')).to.be.true;
+            expect(checkbox.hasClass('not-my-checkbox')).to.be.true;
+        });
+
+        it('accepts disabled prop', () => {
+            const checkbox = mount(<Checkbox disabled>checkbox</Checkbox>);
+
+            expect(checkbox.find('label').hasClass('checkbox_disabled')).to.be.true;
+            expect(checkbox.find('input').node.hasAttribute('disabled')).to.be.true;
+
+            checkbox.setProps({ disabled: false });
+            expect(checkbox.find('label').hasClass('checkbox_disabled')).to.be.false;
+            expect(checkbox.find('input').node.hasAttribute('disabled')).to.be.false;
+        });
+
+        it('accepts checked prop', () => {
+            const checkbox = mount(<Checkbox checked>checkbox</Checkbox>);
+
+            expect(checkbox.find('label').hasClass('checkbox_checked')).to.be.true;
+            expect(checkbox.find('input').node.checked).to.be.true;
+
+            checkbox.setProps({ checked: false });
+            expect(checkbox.find('label').hasClass('checkbox_checked')).to.be.false;
+            expect(checkbox.find('input').node.checked).to.be.false;
+        });
+
+        it('accepts focused prop', () => {
+            const checkbox = mount(<Checkbox focused>checkbox</Checkbox>);
+
+            expect(checkbox.state('focused')).to.be.true;
+            expect(checkbox.find('label').hasClass('checkbox_focused')).to.be.true;
+
+            checkbox.setState({ focused: false });
+            expect(checkbox.find('label').hasClass('checkbox_focused')).to.be.false;
+        });
+
+        it('accepts focus', () => {
+            const checkbox = mount(<Checkbox>checkbox</Checkbox>);
+
+            checkbox.simulate('focus');
+            expect(checkbox.find('label').hasClass('checkbox_focused')).to.be.true;
+
+            checkbox.simulate('blur');
+            expect(checkbox.find('label').hasClass('checkbox_focused')).to.be.false;
+        });
+
+        it('removes focused if receives disabled', () => {
+            const checkbox = mount(<Checkbox focused>checkbox</Checkbox>);
+
+            checkbox.setProps({ disabled: true });
+            expect(checkbox.find('label').hasClass('checkbox_focused')).to.be.false;
+        });
+
+        it('is hovered on mouseenter/mouseleave', () => {
+            const checkbox = mount(<Checkbox>checkbox</Checkbox>);
+
+            expect(checkbox.find('label').hasClass('checkbox_hovered')).to.be.false;
+
+            checkbox.simulate('mouseenter');
+            expect(checkbox.state('hovered')).to.be.true;
+            expect(checkbox.find('label').hasClass('checkbox_hovered')).to.be.true;
+
+            checkbox.simulate('mouseleave');
+            expect(checkbox.state('hovered')).to.be.false;
+            expect(checkbox.find('label').hasClass('checkbox_hovered')).to.be.false;
+        });
+
+        it('can not be hovered if disabled', () => {
+            const checkbox = mount(<Checkbox disabled>checkbox</Checkbox>);
+
+            checkbox.simulate('mouseenter');
+            expect(checkbox.state('hovered')).to.not.be.ok;
+            expect(checkbox.find('label').hasClass('checkbox_hovered')).to.not.be.ok;
+        });
+
+        it('calls onCheck on input change', () => {
+            const spy = sinon.spy();
+            const checkbox = mount(<Checkbox checked={false} onCheck={spy} name="foo">checkbox</Checkbox>);
+
+            checkbox.find('input').simulate('change');
+
+            expect(spy).to.have.been.calledOnce;
+            expect(spy.lastCall).to.have.been.calledWithMatch(true, { name: 'foo' });
+
+            checkbox.setProps({ checked: true });
+            checkbox.find('input').simulate('change');
+
+            expect(spy).to.have.been.calledTwice;
+            expect(spy.lastCall).to.have.been.calledWith(false);
+        });
+
+        it('does not call onCheck if disabled', () => {
+            const spy = sinon.spy();
+            const checkbox = mount(<Checkbox onCheck={spy} disabled>checkbox</Checkbox>);
+
+            checkbox.find('input').simulate('change');
+
+            expect(spy).to.not.have.been.called;
+        });
+    });
+
+    describe('type="button"', () => {
+        it('is a checkbox', () => {
+            const checkbox = shallow(<Checkbox type="button">checkbox</Checkbox>);
+
+            expect(checkbox.is('.checkbox')).to.be.true;
+        });
+
+        it('is a button', () => {
             const checkbox = mount(<Checkbox type="button">checkbox</Checkbox>);
 
             const button = checkbox.find('button');
@@ -46,24 +197,19 @@ describe('Checkbox', () => {
             expect(text.node.textContent).to.equal('checkbox');
         });
 
+        it('has label', () => {
+            const checkbox = mount(<Checkbox type="button">checkbox</Checkbox>);
+
+            const label = checkbox.find('label');
+            expect(label.length).to.equal(1);
+            expect(label.hasClass('checkbox')).to.be.true;
+        });
+
         it('accepts type prop', () => {
             const checkbox = mount(<Checkbox type="button"/>);
 
             expect(checkbox.find('label').hasClass('checkbox_type_button')).to.be.true;
             expect(checkbox.find('button').hasClass('button_type_button')).to.be.true;
-        });
-
-        it('accepts name prop', () => {
-            const checkbox = mount(<Checkbox type="button" name="foo">checkbox</Checkbox>);
-
-            expect(checkbox.find('input').node.getAttribute('name')).to.equal('foo');
-        });
-
-        it('accepts value prop', () => {
-            const checkbox = mount(<Checkbox type="button" value="foo">checkbox</Checkbox>);
-
-            //  FIXME: Почему тут не работает node.getAttribute('value')?
-            expect(checkbox.find('input').node.value).to.equal('foo');
         });
 
         it('accepts theme prop', () => {
@@ -87,8 +233,33 @@ describe('Checkbox', () => {
             expect(checkbox.hasClass('not-my-checkbox')).to.be.true;
         });
 
+        it('accepts checked prop', () => {
+            const checkbox = mount(<Checkbox type="button" checked>checkbox</Checkbox>);
+
+            expect(checkbox.find('label').hasClass('checkbox_checked')).to.be.true;
+            expect(checkbox.find('button').hasClass('button_checked')).to.be.true;
+            expect(checkbox.find('input').length).to.equal(1);
+
+            checkbox.setProps({ checked: false });
+            expect(checkbox.find('label').hasClass('checkbox_checked')).to.be.false;
+            expect(checkbox.find('button').hasClass('button_checked')).to.be.false;
+            expect(checkbox.find('input').length).to.equal(0);
+        });
+
+        it('accepts name prop', () => {
+            const checkbox = mount(<Checkbox type="button" name="foo" checked>checkbox</Checkbox>);
+
+            expect(checkbox.find('input').node.getAttribute('name')).to.equal('foo');
+        });
+
+        it('accepts value prop', () => {
+            const checkbox = mount(<Checkbox type="button" value="foo" checked>checkbox</Checkbox>);
+
+            expect(checkbox.find('input').node.value).to.equal('foo');
+        });
+
         it('accepts disabled prop', () => {
-            const checkbox = mount(<Checkbox type="button" disabled>checkbox</Checkbox>);
+            const checkbox = mount(<Checkbox type="button" checked disabled>checkbox</Checkbox>);
 
             expect(checkbox.find('label').hasClass('checkbox_disabled')).to.be.true;
             expect(checkbox.find('button').hasClass('button_disabled')).to.be.true;
@@ -98,21 +269,6 @@ describe('Checkbox', () => {
             expect(checkbox.find('label').hasClass('checkbox_disabled')).to.be.false;
             expect(checkbox.find('button').hasClass('button_disabled')).to.be.false;
             expect(checkbox.find('input').node.hasAttribute('disabled')).to.be.false;
-        });
-
-        it('accepts checked prop', () => {
-            const checkbox = mount(<Checkbox type="button" checked>checkbox</Checkbox>);
-
-            expect(checkbox.state('checked')).to.be.true;
-            expect(checkbox.find('label').hasClass('checkbox_checked')).to.be.true;
-            expect(checkbox.find('button').hasClass('button_checked')).to.be.true;
-            expect(checkbox.find('input').node.checked).to.be.true;
-
-            checkbox.setProps({ checked: false });
-            expect(checkbox.state('checked')).to.be.false;
-            expect(checkbox.find('label').hasClass('checkbox_checked')).to.be.false;
-            expect(checkbox.find('button').hasClass('button_checked')).to.be.false;
-            expect(checkbox.find('input').node.checked).to.be.false;
         });
 
         it('accepts focused prop', () => {
@@ -181,333 +337,110 @@ describe('Checkbox', () => {
             expect(checkbox.find('button').hasClass('button_hovered')).to.be.false;
         });
 
-        it('can be checked with space or enter if focused', () => {
+        it('calls onCheck handler on space / enter press if focused', () => {
             const spy = sinon.spy();
             const checkbox = mount(<Checkbox type="button" focused onCheck={spy}>checkbox</Checkbox>);
 
-            expect(checkbox.state('checked')).to.not.be.ok;
-
             //  FIXME: А как-то тут не в button можно тыкать? В сам checkbox, например?
             //
-            checkbox.find('button').simulate('keydown', { key: 'q' });
-            checkbox.find('button').simulate('keyup');
-            expect(checkbox.state('checked')).to.not.be.ok;
-
-            checkbox.find('button').simulate('keydown', { key: ' ' });
-            checkbox.find('button').simulate('keyup');
-            expect(checkbox.state('checked')).to.be.true;
-            checkbox.find('button').simulate('keydown', { key: ' ' });
-            checkbox.find('button').simulate('keyup');
-            expect(checkbox.state('checked')).to.be.false;
-
-            checkbox.find('button').simulate('keydown', { key: 'Enter' });
-            checkbox.find('button').simulate('keyup');
-            expect(checkbox.state('checked')).to.be.true;
-            checkbox.find('button').simulate('keydown', { key: 'Enter' });
-            checkbox.find('button').simulate('keyup');
-            expect(checkbox.state('checked')).to.be.false;
-
-            expect(spy.callCount).to.equal(4);
-            expect(spy.getCall(0).args[0]).to.be.true;
-            expect(spy.getCall(1).args[0]).to.be.false;
-            expect(spy.getCall(2).args[0]).to.be.true;
-            expect(spy.getCall(3).args[0]).to.be.false;
-        });
-
-        it('can not be checked with space if disabled', () => {
-            const spy = sinon.spy();
-            const checkbox = mount(<Checkbox type="button" disabled onCheck={spy}>checkbox</Checkbox>);
-
-            expect(checkbox.state('checked')).to.not.be.ok;
-
-            checkbox.find('button').simulate('keydown', { key: ' ' });
-            checkbox.find('button').simulate('keyup');
-            expect(checkbox.state('checked')).to.not.be.ok;
-
+            const button = checkbox.find('button');
+            button.simulate('keydown', { key: 'q' });
+            button.simulate('keyup');
             expect(spy.called).to.be.false;
+
+            button.simulate('keydown', { key: ' ' });
+            button.simulate('keyup');
+            expect(spy.calledOnce).to.be.true;
+            expect(spy.lastCall).to.have.been.calledWith(true);
+
+            checkbox.setProps({ checked: true });
+
+            button.simulate('keydown', { key: ' ' });
+            button.simulate('keyup');
+            expect(spy).to.have.been.calledTwice;
+            expect(spy.lastCall).to.have.been.calledWith(false);
+
+            checkbox.setProps({ checked: false });
+
+            button.simulate('keydown', { key: 'Enter' });
+            button.simulate('keyup');
+            expect(spy).to.have.been.calledThrice;
+            expect(spy.lastCall).to.have.been.calledWith(true);
         });
 
-        it('can be checked with click', () => {
+        it('does not call onCheck on space / enter press if disabled', () => {
+            const spy = sinon.spy();
+            const checkbox = mount(<Checkbox type="button" focused disabled onCheck={spy}>checkbox</Checkbox>);
+
+            const button = checkbox.find('button');
+            button.simulate('keydown', { key: ' ' });
+            button.simulate('keyup');
+            expect(spy).to.not.have.been.called;
+
+            button.simulate('keydown', { key: 'Enter' });
+            button.simulate('keyup');
+            expect(spy).to.not.have.been.called;
+        });
+
+        it('calls onClick on button click', () => {
+            const spy = sinon.spy();
+            const checkbox = mount(<Checkbox type="button" onClick={spy} name="foo">checkbox</Checkbox>);
+
+            const button = checkbox.find('button');
+            button.simulate('mousedown', { button: 0 });
+            button.simulate('mouseup');
+            expect(spy).to.have.been.called;
+        });
+
+        it('calls onCheck on button click', () => {
             const spy = sinon.spy();
             const checkbox = mount(<Checkbox type="button" onCheck={spy} name="foo">checkbox</Checkbox>);
 
-            expect(checkbox.state('checked')).to.not.be.ok;
+            const button = checkbox.find('button');
+            button.simulate('mousedown', { button: 0 });
+            button.simulate('mouseup');
+            expect(spy).to.have.been.calledOnce;
+            expect(spy.lastCall).to.have.been.calledWith(true);
 
-            checkbox.find('button').simulate('mousedown', { button: 0 });
-            checkbox.find('button').simulate('mouseup');
-            expect(checkbox.state('checked')).to.be.true;
+            checkbox.setProps({ checked: true });
 
-            checkbox.find('button').simulate('mousedown', { button: 0 });
-            checkbox.find('button').simulate('mouseup');
-            expect(checkbox.state('checked')).to.be.false;
-
-            expect(spy.callCount).to.equal(2);
-            expect(spy.getCall(0).args[0]).to.be.true;
-            expect(spy.getCall(1).args[0]).to.be.false;
+            button.simulate('mousedown', { button: 0 });
+            button.simulate('mouseup');
+            expect(spy).to.have.been.calledTwice;
+            expect(spy.lastCall).to.have.been.calledWith(false);
         });
 
-        it('onCheck receive props as a second argument', () => {
+        it('does not call onCheck if onClick default prevented', () => {
+            const spy = sinon.spy();
+            const onClick = e => e.preventDefault();
+            const checkbox = mount(<Checkbox type="button" onClick={onClick} onCheck={spy} name="foo">checkbox</Checkbox>);
+
+            const button = checkbox.find('button');
+            button.simulate('mousedown', { button: 0 });
+            button.simulate('mouseup');
+            expect(spy).to.not.have.been.called;
+        });
+
+        it('passes props to onCheck as a second argument', () => {
             const spy = sinon.spy();
             const checkbox = mount(<Checkbox type="button" onCheck={spy} name="foo" bar="42">checkbox</Checkbox>);
 
-            checkbox.find('button').simulate('mousedown', { button: 0 });
-            checkbox.find('button').simulate('mouseup');
+            const button = checkbox.find('button');
+            button.simulate('mousedown', { button: 0 });
+            button.simulate('mouseup');
 
             expect(spy.getCall(0).args[1].name).to.equal('foo');
             expect(spy.getCall(0).args[1].bar).to.equal('42');
         });
 
-        it('can not be checked with click if disabled', () => {
+        it('does not call onCheck on button click if disabled', () => {
             const spy = sinon.spy();
             const checkbox = mount(<Checkbox type="button" disabled onCheck={spy}>checkbox</Checkbox>);
 
-            checkbox.find('button').simulate('mousedown', { button: 0 });
-            checkbox.find('button').simulate('mouseup');
-            expect(checkbox.state('checked')).to.not.be.ok;
-
-            expect(spy.called).to.be.false;
-        });
-
-    });
-
-    describe('type is not set (checkbox)', () => {
-
-        it('is a checkbox', () => {
-            const checkbox = shallow(<Checkbox>checkbox</Checkbox>);
-
-            expect(checkbox.is('.checkbox')).to.be.true;
-        });
-
-        it('has label', () => {
-            const checkbox = mount(<Checkbox>checkbox</Checkbox>);
-
-            const label = checkbox.find('label');
-            expect(label.length).to.equal(1);
-            expect(label.hasClass('checkbox')).to.be.true;
-        });
-
-        it('has input', () => {
-            const checkbox = mount(<Checkbox>checkbox</Checkbox>);
-
-            const input = checkbox.find('input');
-            expect(input.length).to.equal(1);
-            expect(input.hasClass('checkbox__control')).to.be.true;
-            expect(input.node.getAttribute('type')).to.equal('checkbox');
-        });
-
-        it('has no button', () => {
-            const checkbox = mount(<Checkbox>checkbox</Checkbox>);
-
             const button = checkbox.find('button');
-            expect(button.length).to.equal(0);
+            button.simulate('mousedown', { button: 0 });
+            button.simulate('mouseup');
+            expect(spy).to.not.have.been.called;
         });
-
-        it('has text', () => {
-            const checkbox = mount(<Checkbox>checkbox</Checkbox>);
-
-            const text = checkbox.find('span.checkbox__text');
-            expect(text.length).to.equal(1);
-            expect(text.node.textContent).to.equal('checkbox');
-        });
-
-        it('accepts type prop', () => {
-            const checkbox = mount(<Checkbox type="foo"/>);
-
-            expect(checkbox.find('label').hasClass('checkbox_type_foo')).to.be.true;
-        });
-
-        it('accepts name prop', () => {
-            const checkbox = mount(<Checkbox name="foo">checkbox</Checkbox>);
-
-            expect(checkbox.find('input').node.getAttribute('name')).to.equal('foo');
-        });
-
-        it('accepts value prop', () => {
-            const checkbox = mount(<Checkbox value="foo">checkbox</Checkbox>);
-
-            //  FIXME: Почему тут не работает node.getAttribute('value')?
-            expect(checkbox.find('input').node.value).to.equal('foo');
-        });
-
-        it('accepts theme prop', () => {
-            const checkbox = mount(<Checkbox theme="foo">checkbox</Checkbox>);
-
-            expect(checkbox.find('label').hasClass('checkbox_theme_foo')).to.be.true;
-        });
-
-        it('accepts size prop', () => {
-            const checkbox = mount(<Checkbox size="foo">checkbox</Checkbox>);
-
-            expect(checkbox.find('label').hasClass('checkbox_size_foo')).to.be.true;
-        });
-
-        it('accepts className prop', () => {
-            const checkbox = shallow(<Checkbox className="my-checkbox not-my-checkbox">checkbox</Checkbox>);
-
-            expect(checkbox.hasClass('my-checkbox')).to.be.true;
-            expect(checkbox.hasClass('not-my-checkbox')).to.be.true;
-        });
-
-        it('accepts disabled prop', () => {
-            const checkbox = mount(<Checkbox disabled>checkbox</Checkbox>);
-
-            expect(checkbox.find('label').hasClass('checkbox_disabled')).to.be.true;
-            expect(checkbox.find('input').node.hasAttribute('disabled')).to.be.true;
-
-            checkbox.setProps({ disabled: false });
-            expect(checkbox.find('label').hasClass('checkbox_disabled')).to.be.false;
-            expect(checkbox.find('input').node.hasAttribute('disabled')).to.be.false;
-        });
-
-        it('accepts checked prop', () => {
-            const checkbox = mount(<Checkbox checked>checkbox</Checkbox>);
-
-            expect(checkbox.state('checked')).to.be.true;
-            expect(checkbox.find('label').hasClass('checkbox_checked')).to.be.true;
-            expect(checkbox.find('input').node.checked).to.be.true;
-
-            checkbox.setProps({ checked: false });
-            expect(checkbox.state('checked')).to.be.false;
-            expect(checkbox.find('label').hasClass('checkbox_checked')).to.be.false;
-            expect(checkbox.find('input').node.checked).to.be.false;
-        });
-
-        it('accepts focused prop', () => {
-            const checkbox = mount(<Checkbox focused>checkbox</Checkbox>);
-
-            expect(checkbox.state('focused')).to.be.true;
-            expect(checkbox.find('label').hasClass('checkbox_focused')).to.be.true;
-
-            checkbox.setState({ focused: false });
-            expect(checkbox.find('label').hasClass('checkbox_focused')).to.be.false;
-        });
-
-        it('accepts focus', () => {
-            const checkbox = mount(<Checkbox>checkbox</Checkbox>);
-
-            checkbox.simulate('focus');
-            expect(checkbox.find('label').hasClass('checkbox_focused')).to.be.true;
-
-            checkbox.simulate('blur');
-            expect(checkbox.find('label').hasClass('checkbox_focused')).to.be.false;
-        });
-
-        it('removes focused if receives disabled', () => {
-            const checkbox = mount(<Checkbox focused>checkbox</Checkbox>);
-
-            checkbox.setProps({ disabled: true });
-            expect(checkbox.find('label').hasClass('checkbox_focused')).to.be.false;
-        });
-
-        it('is hovered on mouseenter/mouseleave', () => {
-            const checkbox = mount(<Checkbox>checkbox</Checkbox>);
-
-            expect(checkbox.find('label').hasClass('checkbox_hovered')).to.be.false;
-
-            checkbox.simulate('mouseenter');
-            expect(checkbox.state('hovered')).to.be.true;
-            expect(checkbox.find('label').hasClass('checkbox_hovered')).to.be.true;
-
-            checkbox.simulate('mouseleave');
-            expect(checkbox.state('hovered')).to.be.false;
-            expect(checkbox.find('label').hasClass('checkbox_hovered')).to.be.false;
-        });
-
-        it('can not be hovered if disabled', () => {
-            const checkbox = mount(<Checkbox disabled>checkbox</Checkbox>);
-
-            checkbox.simulate('mouseenter');
-            expect(checkbox.state('hovered')).to.not.be.ok;
-            expect(checkbox.find('label').hasClass('checkbox_hovered')).to.not.be.ok;
-        });
-
-        //  FIXME: Не работает чек с клавиатуры и мыши.
-        //
-        it.skip('can be checked with space or enter if focused', () => {
-            const spy = sinon.spy();
-            const checkbox = mount(<Checkbox focused onCheck={spy}>checkbox</Checkbox>);
-
-            expect(checkbox.state('checked')).to.not.be.ok;
-
-            checkbox.find('input').simulate('keydown', { key: 'q' });
-            checkbox.find('input').simulate('keyup');
-            expect(checkbox.state('checked')).to.not.be.ok;
-            checkbox.find('input').simulate('keydown', { key: ' ' });
-            checkbox.find('input').simulate('keyup');
-            expect(checkbox.state('checked')).to.be.true;
-            checkbox.find('input').simulate('keydown', { key: ' ' });
-            checkbox.find('input').simulate('keyup');
-            expect(checkbox.state('checked')).to.be.false;
-
-            checkbox.find('input').simulate('keydown', { key: 'Enter' });
-            checkbox.find('input').simulate('keyup');
-            expect(checkbox.state('checked')).to.be.true;
-            checkbox.find('input').simulate('keydown', { key: 'Enter' });
-            checkbox.find('input').simulate('keyup');
-            expect(checkbox.state('checked')).to.be.false;
-
-            expect(spy.callCount).to.equal(4);
-            expect(spy.getCall(0).args[0]).to.be.true;
-            expect(spy.getCall(1).args[0]).to.be.false;
-            expect(spy.getCall(2).args[0]).to.be.true;
-            expect(spy.getCall(3).args[0]).to.be.false;
-        });
-
-        it.skip('can not be checked with space if disabled', () => {
-            const spy = sinon.spy();
-            const checkbox = mount(<Checkbox disabled onCheck={spy}>checkbox</Checkbox>);
-
-            expect(checkbox.state('checked')).to.not.be.ok;
-
-            checkbox.find('input').simulate('keydown', { key: ' ' });
-            checkbox.find('input').simulate('keyup');
-            expect(checkbox.state('checked')).to.not.be.ok;
-
-            expect(spy.called).to.be.false;
-        });
-
-        it.skip('can be checked with click', () => {
-            const spy = sinon.spy();
-            const checkbox = mount(<Checkbox onCheck={spy}>checkbox</Checkbox>);
-
-            expect(checkbox.state('checked')).to.not.be.ok;
-
-            checkbox.find('input').simulate('mousedown');
-            checkbox.find('input').simulate('mouseup');
-            expect(checkbox.state('checked')).to.be.true;
-
-            checkbox.find('input').simulate('mousedown');
-            checkbox.find('input').simulate('mouseup');
-            expect(checkbox.state('checked')).to.be.false;
-
-            expect(spy.callCount).to.equal(2);
-            expect(spy.getCall(0).args[0]).to.be.true;
-            expect(spy.getCall(1).args[0]).to.be.false;
-        });
-
-        it.skip('onCheck receive props as a second argument', () => {
-            const spy = sinon.spy();
-            const checkbox = mount(<Checkbox onCheck={spy} name="foo" bar="42">checkbox</Checkbox>);
-
-            checkbox.find('input').simulate('mousedown');
-            checkbox.find('input').simulate('mouseup');
-
-            expect(spy.getCall(0).args[1].name).to.equal('foo');
-            expect(spy.getCall(0).args[1].bar).to.equal('42');
-        });
-
-        //  FIXME: На самом деле это неправильный тест (хоть он и проходит),
-        //  так как сейчас вообще никакие клики checked не меняют :(
-        it.skip('can not be checked with click if disabled', () => {
-            const spy = sinon.spy();
-            const checkbox = mount(<Checkbox disabled onCheck={spy}>checkbox</Checkbox>);
-
-            checkbox.find('input').simulate('mousedown');
-            checkbox.find('input').simulate('mouseup');
-            expect(checkbox.state('checked')).to.not.be.ok;
-
-            expect(spy.called).to.be.false;
-        });
-
     });
 });

--- a/src/CheckboxGroup/examples.js
+++ b/src/CheckboxGroup/examples.js
@@ -35,7 +35,7 @@ class Example extends React.Component {
                     </div>
 
                     <div className="example">
-                        <CheckboxGroup size="m" type="button" name="b" onChange={this.onChange}>
+                        <CheckboxGroup size="m" type="button" name="b" value={this.state.b} onChange={this.onChange}>
                             <Checkbox value="10">10</Checkbox>
                             <Checkbox value="20">20</Checkbox>
                             <Checkbox value="30">30</Checkbox>
@@ -57,7 +57,7 @@ class Example extends React.Component {
                     </div>
 
                     <div className="example">
-                        <CheckboxGroup size="m" type="line" name="d" onChange={this.onChange}>
+                        <CheckboxGroup size="m" type="line" name="d" value={this.state.d} onChange={this.onChange}>
                             <Checkbox value="10">10</Checkbox>
                             <Checkbox value="20">20</Checkbox>
                             <Checkbox value="30">30</Checkbox>

--- a/src/CheckboxGroup/index.js
+++ b/src/CheckboxGroup/index.js
@@ -6,22 +6,11 @@ class CheckboxGroup extends Component {
     constructor(props) {
         super(props);
 
-        const value = props.value != null ? [...props.value] : [];
-        this.state = { value };
-
         this.onChildCheck = this.onChildCheck.bind(this);
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.value !== this.props.value) {
-            this.setState({ value: nextProps.value != null ? [...nextProps.value] : []});
-        }
-    }
-
     render() {
-        const onChildCheck = this.onChildCheck;
-        const { value } = this.state;
-        const { theme, size, type, name, disabled } = this.props;
+        const { theme, size, type, name, disabled, value } = this.props;
 
         const children = React.Children.map(this.props.children, child => {
             const checked = value.indexOf(child.props.value) !== -1;
@@ -33,7 +22,7 @@ class CheckboxGroup extends Component {
                 disabled,
                 ...child.props,
                 checked,
-                onCheck: onChildCheck,
+                onCheck: this.onChildCheck,
             });
         });
 
@@ -66,17 +55,16 @@ class CheckboxGroup extends Component {
     }
 
     onChildCheck(checked, childProps) {
-        const value = childProps.value;
-        if (checked && this.state.value.indexOf(value) === -1) {
+        const { value } = this.props;
+        const childValue = childProps.value;
+        if (checked && value.indexOf(childValue) === -1) {
             //  FIXME: Не нужно ли тут возвращать массив в том же порядке,
             //  как эти значение в RadioGroup расположены?
             //
-            let newValue = this.state.value.concat(value);
-            this.setState({ value: newValue });
+            const newValue = value.concat(childValue);
             this.props.onChange(newValue, this.props);
         } else if (!checked) {
-            let newValue = this.state.value.filter(item => (item !== value));
-            this.setState({ value: newValue });
+            const newValue = value.filter(item => (item !== childValue));
             this.props.onChange(newValue, this.props);
         }
     }
@@ -86,17 +74,19 @@ CheckboxGroup.contextTypes = {
     theme: React.PropTypes.string,
 };
 
-CheckboxGroup.defaultProps = {
-    onChange() {},
-};
-
 CheckboxGroup.propTypes = {
     theme: React.PropTypes.string,
-    size: React.PropTypes.oneOf(['m', 'l']),
+    size: React.PropTypes.oneOf(['m', 'l', 'xl']),
     type: React.PropTypes.string,
     name: React.PropTypes.string,
+    disabled: React.PropTypes.bool,
     value: React.PropTypes.any,
     onChange: React.PropTypes.func,
+};
+
+CheckboxGroup.defaultProps = {
+    value: [],
+    onChange() {},
 };
 
 export default CheckboxGroup;

--- a/src/CheckboxGroup/test.js
+++ b/src/CheckboxGroup/test.js
@@ -1,180 +1,19 @@
 /* eslint-env mocha */
 
 import React from 'react';
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
 import { shallow, mount } from 'enzyme';
+import chaiEnzyme from 'chai-enzyme';
 import sinon from 'sinon';
-
+import sinonChai from 'sinon-chai';
 import CheckboxGroup from './';
 import Checkbox from '../Checkbox';
 
+chai.use(sinonChai);
+chai.use(chaiEnzyme());
+
 describe('CheckboxGroup', () => {
-
-    describe('type="button"', () => {
-
-        it('is a checkbox-group', () => {
-            const group = shallow(
-                <CheckboxGroup type="button"/>
-            );
-
-            expect(group.is('.checkbox-group')).to.be.true;
-        });
-
-        it('has checkboxes', () => {
-            const group = mount(
-                <CheckboxGroup type="button">
-                    <Checkbox value="10">10</Checkbox>
-                    <Checkbox value="20">20</Checkbox>
-                    <Checkbox value="30">30</Checkbox>
-                </CheckboxGroup>
-            );
-
-            const checkboxes = group.find('.checkbox');
-            expect(checkboxes.length).to.equal(3);
-        });
-
-        it('accepts className prop', () => {
-            const group = shallow(
-                <CheckboxGroup type="button" className="my-checkbox-group not-my-checkbox-group"/>
-            );
-
-            expect(group.hasClass('my-checkbox-group')).to.be.true;
-            expect(group.hasClass('not-my-checkbox-group')).to.be.true;
-        });
-
-        it('accepts type prop', () => {
-            const wrapper = mount(
-                <CheckboxGroup type="button">
-                    <Checkbox value="10">10</Checkbox>
-                </CheckboxGroup>
-            );
-            const group = wrapper.find('.checkbox-group');
-
-            expect(group.hasClass('checkbox-group_type_button')).to.be.true;
-
-            const checkbox = group.find('.checkbox');
-            expect(checkbox.hasClass('checkbox_type_button')).to.be.true;
-        });
-
-        it('accepts theme prop', () => {
-            const wrapper = mount(
-                <CheckboxGroup type="button" theme="foo">
-                    <Checkbox value="10">10</Checkbox>
-                </CheckboxGroup>
-            );
-            const group = wrapper.find('.checkbox-group');
-
-            expect(group.hasClass('checkbox-group_theme_foo')).to.be.true;
-
-            const checkbox = group.find('.checkbox');
-            expect(checkbox.hasClass('checkbox_theme_foo')).to.be.true;
-        });
-
-        it('accepts size prop', () => {
-            const wrapper = mount(
-                <CheckboxGroup type="button" size="m">
-                    <Checkbox value="10">10</Checkbox>
-                </CheckboxGroup>
-            );
-            const group = wrapper.find('.checkbox-group');
-
-            expect(group.hasClass('checkbox-group_size_m')).to.be.true;
-
-            const checkbox = group.find('.checkbox');
-            expect(checkbox.hasClass('checkbox_size_m')).to.be.true;
-        });
-
-        it('accepts name prop', () => {
-            const wrapper = mount(
-                <CheckboxGroup type="button" name="foo">
-                    <Checkbox value="10">10</Checkbox>
-                </CheckboxGroup>
-            );
-            const group = wrapper.find('.checkbox-group');
-
-            const checkbox = group.find('.checkbox');
-            //  Не получится тут тестить `checkbox.prop('name')`.
-            //  Придется лезть в DOM руками.
-            expect(checkbox.find('input').node.getAttribute('name')).to.equal('foo');
-        });
-
-        it('accepts value prop', () => {
-            const wrapper = mount(
-                <CheckboxGroup type="button" value={['10', '30']}>
-                    <Checkbox value="10">10</Checkbox>
-                    <Checkbox value="20">20</Checkbox>
-                    <Checkbox value="30">30</Checkbox>
-                </CheckboxGroup>
-            );
-            const group = wrapper.find('.checkbox-group');
-
-            const checkboxes = group.find('.checkbox');
-            expect(checkboxes.at(0).hasClass('checkbox_checked')).to.be.true;
-            expect(checkboxes.at(1).hasClass('checkbox_checked')).to.be.false;
-            expect(checkboxes.at(2).hasClass('checkbox_checked')).to.be.true;
-        });
-
-        it('can change value via setState', () => {
-            const wrapper = mount(
-                <CheckboxGroup type="button" value={['10', '30']}>
-                    <Checkbox value="10">10</Checkbox>
-                    <Checkbox value="20">20</Checkbox>
-                    <Checkbox value="30">30</Checkbox>
-                </CheckboxGroup>
-            );
-            const group = wrapper.find('.checkbox-group');
-
-            wrapper.setState({ value: ['20'] });
-
-            const checkboxes = group.find('.checkbox');
-            expect(checkboxes.at(0).hasClass('checkbox_checked')).to.be.false;
-            expect(checkboxes.at(1).hasClass('checkbox_checked')).to.be.true;
-            expect(checkboxes.at(2).hasClass('checkbox_checked')).to.be.false;
-        });
-
-        it('accepts disabled prop', () => {
-            const wrapper = mount(
-                <CheckboxGroup type="button" disabled>
-                    <Checkbox value="10">10</Checkbox>
-                </CheckboxGroup>
-            );
-            const group = wrapper.find('.checkbox-group');
-
-            const checkbox = group.find('.checkbox');
-            expect(checkbox.hasClass('checkbox_disabled')).to.be.true;
-
-            wrapper.setProps({ disabled: false });
-            expect(checkbox.hasClass('checkbox_disabled')).to.be.false;
-        });
-
-        it('change value if checkbox clicked', () => {
-            const spy = sinon.spy();
-            const wrapper = mount(
-                <CheckboxGroup type="button" value={['10', '30']} onChange={spy} foo="bar">
-                    <Checkbox value="10">10</Checkbox>
-                    <Checkbox value="20">20</Checkbox>
-                    <Checkbox value="30">30</Checkbox>
-                </CheckboxGroup>
-            );
-            const group = wrapper.find('.checkbox-group');
-
-            const secondCheckboxButton = group
-                .find('.checkbox')
-                .at(1)
-                .find('button');
-            secondCheckboxButton.simulate('mousedown', { button: 0 });
-            secondCheckboxButton.simulate('mouseup');
-
-            expect(wrapper.state('value')).to.be.eql(['10', '30', '20']);
-
-            expect(spy.callCount).to.equal(1);
-            expect(spy.getCall(0).args[1].foo).to.equal('bar');
-        });
-
-    });
-
     describe('type="line"', () => {
-
         it('is a checkbox-group', () => {
             const group = shallow(
                 <CheckboxGroup type="line"/>
@@ -253,12 +92,8 @@ describe('CheckboxGroup', () => {
                     <Checkbox value="10">10</Checkbox>
                 </CheckboxGroup>
             );
-            const group = wrapper.find('.checkbox-group');
-
-            const checkbox = group.find('.checkbox');
-            //  Не получится тут тестить `checkbox.prop('name')`.
-            //  Придется лезть в DOM руками.
-            expect(checkbox.find('input').node.getAttribute('name')).to.equal('foo');
+            const checkbox = wrapper.find('.checkbox-group').find(Checkbox);
+            expect(checkbox).to.have.prop('name', 'foo');
         });
 
         it('accepts value prop', () => {
@@ -269,15 +104,14 @@ describe('CheckboxGroup', () => {
                     <Checkbox value="30">30</Checkbox>
                 </CheckboxGroup>
             );
-            const group = wrapper.find('.checkbox-group');
 
-            const checkboxes = group.find('.checkbox');
-            expect(checkboxes.at(0).hasClass('checkbox_checked')).to.be.true;
-            expect(checkboxes.at(1).hasClass('checkbox_checked')).to.be.false;
-            expect(checkboxes.at(2).hasClass('checkbox_checked')).to.be.true;
+            const checkboxes = wrapper.find('.checkbox-group').find(Checkbox);
+            expect(checkboxes.at(0)).to.have.prop('checked', true);
+            expect(checkboxes.at(1)).to.not.have.prop('checked', true);
+            expect(checkboxes.at(2)).to.have.prop('checked', true);
         });
 
-        it('can change value via setState', () => {
+        it('updates children on value change', () => {
             const wrapper = mount(
                 <CheckboxGroup type="line" value={['10', '30']}>
                     <Checkbox value="10">10</Checkbox>
@@ -285,19 +119,169 @@ describe('CheckboxGroup', () => {
                     <Checkbox value="30">30</Checkbox>
                 </CheckboxGroup>
             );
-            const group = wrapper.find('.checkbox-group');
 
-            wrapper.setState({ value: ['20'] });
+            wrapper.setProps({ value: ['20'] });
 
-            const checkboxes = group.find('.checkbox');
-            expect(checkboxes.at(0).hasClass('checkbox_checked')).to.be.false;
-            expect(checkboxes.at(1).hasClass('checkbox_checked')).to.be.true;
-            expect(checkboxes.at(2).hasClass('checkbox_checked')).to.be.false;
+            const checkboxes = wrapper.find('.checkbox-group').find(Checkbox);
+            expect(checkboxes.at(0)).to.not.have.prop('checked', true);
+            expect(checkboxes.at(1)).to.have.prop('checked', true);
+            expect(checkboxes.at(2)).to.not.have.prop('checked', true);
         });
 
         it('accepts disabled prop', () => {
             const wrapper = mount(
                 <CheckboxGroup type="line" disabled>
+                    <Checkbox value="10">10</Checkbox>
+                </CheckboxGroup>
+            );
+            const checkbox = wrapper.find('.checkbox-group').find(Checkbox);
+            expect(checkbox).to.have.prop('disabled', true);
+
+            wrapper.setProps({ disabled: false });
+
+            expect(checkbox).to.not.have.prop('disabled', true);
+        });
+
+        it('calls onChange handler on Checkbox change', () => {
+            const spy = sinon.spy();
+            const wrapper = mount(
+                <CheckboxGroup type="line" value={['10', '30']} onChange={spy} foo="bar">
+                    <Checkbox value="10">10</Checkbox>
+                    <Checkbox value="20">20</Checkbox>
+                    <Checkbox value="30">30</Checkbox>
+                </CheckboxGroup>
+            );
+
+            const checkbox2 = wrapper.find(Checkbox)
+                .at(1)
+                .find('input');
+
+            checkbox2.simulate('change');
+
+            expect(spy).to.have.been.calledOnce;
+            expect(spy.lastCall.args[0]).to.have.members(['10', '20', '30']);
+            expect(spy.lastCall.args[1].foo).to.equal('bar');
+        });
+    });
+
+    describe('type="button"', () => {
+        it('is a checkbox-group', () => {
+            const group = shallow(
+                <CheckboxGroup type="button"/>
+            );
+
+            expect(group.is('.checkbox-group')).to.be.true;
+        });
+
+        it('has checkboxes', () => {
+            const group = mount(
+                <CheckboxGroup type="button">
+                    <Checkbox value="10">10</Checkbox>
+                    <Checkbox value="20">20</Checkbox>
+                    <Checkbox value="30">30</Checkbox>
+                </CheckboxGroup>
+            );
+
+            const checkboxes = group.find('.checkbox');
+            expect(checkboxes.length).to.equal(3);
+        });
+
+        it('accepts className prop', () => {
+            const group = shallow(
+                <CheckboxGroup type="button" className="my-checkbox-group not-my-checkbox-group"/>
+            );
+
+            expect(group.hasClass('my-checkbox-group')).to.be.true;
+            expect(group.hasClass('not-my-checkbox-group')).to.be.true;
+        });
+
+        it('accepts type prop', () => {
+            const wrapper = mount(
+                <CheckboxGroup type="button">
+                    <Checkbox value="10">10</Checkbox>
+                </CheckboxGroup>
+            );
+            const group = wrapper.find('.checkbox-group');
+
+            expect(group.hasClass('checkbox-group_type_button')).to.be.true;
+
+            const checkbox = group.find('.checkbox');
+            expect(checkbox.hasClass('checkbox_type_button')).to.be.true;
+        });
+
+        it('accepts theme prop', () => {
+            const wrapper = mount(
+                <CheckboxGroup type="button" theme="foo">
+                    <Checkbox value="10">10</Checkbox>
+                </CheckboxGroup>
+            );
+            const group = wrapper.find('.checkbox-group');
+
+            expect(group.hasClass('checkbox-group_theme_foo')).to.be.true;
+
+            const checkbox = group.find('.checkbox');
+            expect(checkbox.hasClass('checkbox_theme_foo')).to.be.true;
+        });
+
+        it('accepts size prop', () => {
+            const wrapper = mount(
+                <CheckboxGroup type="button" size="m">
+                    <Checkbox value="10">10</Checkbox>
+                </CheckboxGroup>
+            );
+            const group = wrapper.find('.checkbox-group');
+
+            expect(group.hasClass('checkbox-group_size_m')).to.be.true;
+
+            const checkbox = group.find('.checkbox');
+            expect(checkbox.hasClass('checkbox_size_m')).to.be.true;
+        });
+
+        it('accepts name prop', () => {
+            const wrapper = mount(
+                <CheckboxGroup type="button" name="foo">
+                    <Checkbox value="10">10</Checkbox>
+                </CheckboxGroup>
+            );
+            const checkbox = wrapper.find('.checkbox-group').find(Checkbox);
+            expect(checkbox).to.have.prop('name', 'foo');
+        });
+
+        it('accepts value prop', () => {
+            const wrapper = mount(
+                <CheckboxGroup type="button" value={['10', '30']}>
+                    <Checkbox value="10">10</Checkbox>
+                    <Checkbox value="20">20</Checkbox>
+                    <Checkbox value="30">30</Checkbox>
+                </CheckboxGroup>
+            );
+
+            const checkboxes = wrapper.find('.checkbox-group').find(Checkbox);
+            expect(checkboxes.at(0)).to.have.prop('checked', true);
+            expect(checkboxes.at(1)).to.not.have.prop('checked', true);
+            expect(checkboxes.at(2)).to.have.prop('checked', true);
+        });
+
+        it('updates children on value change', () => {
+            const wrapper = mount(
+                <CheckboxGroup type="button" value={['10', '30']}>
+                    <Checkbox value="10">10</Checkbox>
+                    <Checkbox value="20">20</Checkbox>
+                    <Checkbox value="30">30</Checkbox>
+                </CheckboxGroup>
+            );
+
+            wrapper.setProps({ value: ['20'] });
+
+            const checkboxes = wrapper.find('.checkbox-group').find(Checkbox);
+            expect(checkboxes.at(0)).to.not.have.prop('checked', true);
+            expect(checkboxes.at(1)).to.have.prop('checked', true);
+            expect(checkboxes.at(2)).to.not.have.prop('checked', true);
+        });
+
+        it('accepts disabled prop', () => {
+            const wrapper = mount(
+                <CheckboxGroup type="button" disabled>
                     <Checkbox value="10">10</Checkbox>
                 </CheckboxGroup>
             );
@@ -310,30 +294,25 @@ describe('CheckboxGroup', () => {
             expect(checkbox.hasClass('checkbox_disabled')).to.be.false;
         });
 
-        //  FIXME: Не получается правильно сэмулировать клик в чекбокс.
-        it.skip('change value if checkbox clicked', () => {
+        it('change value if checkbox clicked', () => {
             const spy = sinon.spy();
             const wrapper = mount(
-                <CheckboxGroup type="line" value={['10', '30']} onChange={spy} foo="bar">
+                <CheckboxGroup type="button" value={['10', '30']} onChange={spy} foo="bar">
                     <Checkbox value="10">10</Checkbox>
                     <Checkbox value="20">20</Checkbox>
                     <Checkbox value="30">30</Checkbox>
                 </CheckboxGroup>
             );
-            const group = wrapper.find('.checkbox-group');
 
-            const secondCheckboxButton = group
-                .find('.checkbox')
+            const secondCheckboxButton = wrapper.find(Checkbox)
                 .at(1)
                 .find('button');
             secondCheckboxButton.simulate('mousedown', { button: 0 });
             secondCheckboxButton.simulate('mouseup');
 
-            expect(wrapper.state('value')).to.be.eql(['10', '30', '20']);
-
-            expect(spy.callCount).to.equal(1);
-            expect(spy.getCall(0).args[1].foo).to.equal('bar');
+            expect(spy).to.have.been.calledOnce;
+            expect(spy.lastCall.args[0]).to.have.members(['10', '20', '30']);
+            expect(spy.lastCall.args[1].foo).to.equal('bar');
         });
-
     });
 });


### PR DESCRIPTION
- get rid of components own states
- get rid-off internal `<input type=checkbox>` in `Checkbox(type=button)`
- update chai-enzyme
- add sinon-chai
- fix tests
- add example to Checkbox

Relates to #63 
