### PR TITLE
Radio, RadioGroup: make components stateless

### DIFF
--- a/src/Radio/examples.js
+++ b/src/Radio/examples.js
@@ -1,0 +1,40 @@
+import React, { Component } from 'react';
+import App from '../App';
+import Radio from './';
+
+class RadioExample extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            checked: true,
+        };
+    }
+
+    render() {
+        return (
+            <div className="example">
+                <Radio theme="islands" size="m" name="c1"
+                    {...this.props}
+                    checked={this.state.checked}
+                    onCheck={checked => this.onCheck(checked)}
+                />
+            </div>
+        );
+    }
+
+    onCheck(checked) {
+        this.setState({ checked });
+    }
+}
+
+export default function Example() {
+    return (
+        <App theme="islands">
+            <div className="examples">
+                <RadioExample />
+                <RadioExample type="button">Push me!</RadioExample>
+            </div>
+        </App>
+    );
+}

--- a/src/Radio/index.js
+++ b/src/Radio/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import Control from '../Control';
 import Button from '../Button';
 
@@ -7,38 +6,20 @@ class Radio extends Control {
     constructor(props) {
         super(props);
 
-        this.state = {
-            ...this.state,
-            checked: props.checked,
-        };
-
         this.onButtonClick = this.onButtonClick.bind(this);
         this.onButtonFocusChange = this.onButtonFocusChange.bind(this);
         this.onButtonHoverChange = this.onButtonHoverChange.bind(this);
         this.onControlChange = this.onControlChange.bind(this);
     }
 
-    /** @override */
-    componentWillReceiveProps(nextProps) {
-        super.componentWillReceiveProps(nextProps);
-
-        // NOTE(narqo@): `setState({ checked })` must be called only if new `checked` value was passed
-        // or `Checkbox` will stay in the `checked` state regardless the DOM events.
-        if (this.props.checked !== nextProps.checked) {
-            this.setState({
-                ...this.state,
-                checked: nextProps.checked,
-            });
-        }
-    }
-
     render() {
-        const { name, theme, size, type, disabled, value } = this.props;
-        const { checked, focused } = this.state;
+        const { name, theme, size, type, checked, disabled, value } = this.props;
+        const { focused } = this.state;
 
         if (type === 'button') {
             return (
                 <label className={this.className()}>
+                    {checked && <input type="hidden" name={name} value={value} disabled={disabled} />}
                     <Button theme={theme} size={size} type={type}
                         disabled={disabled}
                         checked={checked}
@@ -49,12 +30,6 @@ class Radio extends Control {
                     >
                         {this.props.children}
                     </Button>
-                    <input ref="control" className="radio__control" type="radio" autoComplete="off"
-                        name={name}
-                        disabled={disabled}
-                        defaultValue={value}
-                        defaultChecked={checked}
-                    />
                 </label>
             )
         } else {
@@ -78,7 +53,7 @@ class Radio extends Control {
     }
 
     className() {
-        var className = 'radio';
+        let className = 'radio';
 
         const theme = this.props.theme || this.context.theme;
         if (theme) {
@@ -93,14 +68,14 @@ class Radio extends Control {
         if (this.props.disabled) {
             className += ' radio_disabled';
         }
+        if (this.props.checked) {
+            className += ' radio_checked';
+        }
         if (this.state.hovered) {
             className += ' radio_hovered';
         }
         if (this.state.focused) {
             className += ' radio_focused';
-        }
-        if (this.state.checked) {
-            className += ' radio_checked';
         }
 
         if (this.props.className) {
@@ -108,6 +83,13 @@ class Radio extends Control {
         }
 
         return className;
+    }
+
+    onControlChange() {
+        if (this.props.disabled || this.props.checked) {
+            return;
+        }
+        this.props.onCheck(true, this.props);
     }
 
     onButtonFocusChange(focused) {
@@ -118,29 +100,28 @@ class Radio extends Control {
         this.setState({ hovered });
     }
 
-    onButtonClick() {
-        //  FIXME: Может передавать туда name, value?
-        this.props.onClick();
-
-        if (!this.state.checked) {
-            // FIXME(narqo@): `this.refs.control.checked = checked`
-            this.refs.control.checked = true;
-            this.setState({ checked: true });
-
-            this.props.onCheck(true, this.props);
+    onButtonClick(e) {
+        if (this.props.onClick) {
+            this.props.onClick(e, this.props);
         }
-    }
-
-    onControlChange() {
-        //  Тут checked всегда становится true.
-        //  Измениться с true на falsy оно может только через props.
-        this.setState({ checked: true });
-        this.props.onCheck(true, this.props);
+        if (!e.isDefaultPrevented()) {
+            this.onControlChange();
+        }
     }
 }
 
+Radio.propTypes = {
+    theme: React.PropTypes.string,
+    size: React.PropTypes.oneOf(['s', 'm', 'l', 'xl']),
+    type: React.PropTypes.string,
+    disabled: React.PropTypes.bool,
+    checked: React.PropTypes.bool,
+    value: React.PropTypes.any,
+    onClick: React.PropTypes.func,
+    onCheck: React.PropTypes.func,
+};
+
 Radio.defaultProps = {
-    onClick() {},
     onCheck() {},
 };
 

--- a/src/Radio/test.js
+++ b/src/Radio/test.js
@@ -1,290 +1,18 @@
 /* eslint-env mocha */
 
 import React from 'react';
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
+import chaiEnzyme from 'chai-enzyme';
 import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
-
+import sinonChai from 'sinon-chai';
 import Radio from './';
 
+chai.use(sinonChai);
+chai.use(chaiEnzyme());
+
 describe('Radio', () => {
-
-    describe('type="button"', () => {
-
-        it('is a radio', () => {
-            const radio = shallow(<Radio type="button">radio</Radio>);
-
-            expect(radio.is('.radio')).to.be.true;
-        });
-
-        it('has label', () => {
-            const radio = mount(<Radio type="button">radio</Radio>);
-
-            const label = radio.find('label');
-            expect(label.length).to.equal(1);
-            expect(label.hasClass('radio')).to.be.true;
-        });
-
-        it('has input', () => {
-            const radio = mount(<Radio type="button">radio</Radio>);
-
-            const input = radio.find('input');
-            expect(input.length).to.equal(1);
-            expect(input.hasClass('radio__control')).to.be.true;
-            expect(input.node.getAttribute('type')).to.equal('radio');
-        });
-
-        it('has button', () => {
-            const radio = mount(<Radio type="button">radio</Radio>);
-
-            const button = radio.find('button');
-            expect(button.length).to.equal(1);
-            expect(button.hasClass('button')).to.be.true;
-
-            const text = button.find('span');
-            expect(text.hasClass('button__text')).to.be.true;
-            expect(text.node.textContent).to.equal('radio');
-        });
-
-        it('accepts type prop', () => {
-            const radio = mount(<Radio type="button"/>);
-
-            expect(radio.find('label').hasClass('radio_type_button')).to.be.true;
-            expect(radio.find('button').hasClass('button_type_button')).to.be.true;
-        });
-
-        it('accepts name prop', () => {
-            const radio = mount(<Radio type="button" name="foo">radio</Radio>);
-
-            expect(radio.find('input').node.getAttribute('name')).to.equal('foo');
-        });
-
-        it('accepts value prop', () => {
-            const radio = mount(<Radio type="button" value="foo">radio</Radio>);
-
-            //  FIXME: Почему тут не работает node.getAttribute('value')?
-            expect(radio.find('input').node.value).to.equal('foo');
-        });
-
-        it('accepts theme prop', () => {
-            const radio = mount(<Radio type="button" theme="foo">radio</Radio>);
-
-            expect(radio.find('label').hasClass('radio_theme_foo')).to.be.true;
-            expect(radio.find('button').hasClass('button_theme_foo')).to.be.true;
-        });
-
-        it('accepts size prop', () => {
-            const radio = mount(<Radio type="button" size="foo">radio</Radio>);
-
-            expect(radio.find('label').hasClass('radio_size_foo')).to.be.true;
-            expect(radio.find('button').hasClass('button_size_foo')).to.be.true;
-        });
-
-        it('accepts className prop', () => {
-            const radio = shallow(<Radio type="button" className="my-radio not-my-radio">radio</Radio>);
-
-            expect(radio.hasClass('my-radio')).to.be.true;
-            expect(radio.hasClass('not-my-radio')).to.be.true;
-        });
-
-        it('accepts disabled prop', () => {
-            const radio = mount(<Radio type="button" disabled>radio</Radio>);
-
-            expect(radio.find('label').hasClass('radio_disabled')).to.be.true;
-            expect(radio.find('button').hasClass('button_disabled')).to.be.true;
-            expect(radio.find('input').node.hasAttribute('disabled')).to.be.true;
-
-            radio.setProps({ disabled: false });
-            expect(radio.find('label').hasClass('radio_disabled')).to.be.false;
-            expect(radio.find('button').hasClass('button_disabled')).to.be.false;
-            expect(radio.find('input').node.hasAttribute('disabled')).to.be.false;
-        });
-
-        it.skip('accepts checked prop', () => {
-            const radio = mount(<Radio type="button" checked>radio</Radio>);
-
-            expect(radio.state('checked')).to.be.true;
-            expect(radio.find('label').hasClass('radio_checked')).to.be.true;
-            expect(radio.find('button').hasClass('button_checked')).to.be.true;
-            //  FIXME: Почему-то не работает. В Checkbox все ок.
-            expect(radio.find('input').node.checked).to.be.true;
-
-            radio.setProps({ checked: false });
-            expect(radio.state('checked')).to.be.false;
-            expect(radio.find('label').hasClass('radio_checked')).to.be.false;
-            expect(radio.find('button').hasClass('button_checked')).to.be.false;
-            //  FIXME: И тут.
-            expect(radio.find('input').node.checked).to.be.false;
-        });
-
-        it('accepts focused prop', () => {
-            const radio = mount(<Radio type="button" focused>radio</Radio>);
-
-            expect(radio.state('focused')).to.be.true;
-            expect(radio.find('label').hasClass('radio_focused')).to.be.true;
-            expect(radio.find('button').hasClass('button_focused')).to.be.true;
-
-            // FIXME(narqo@): `Control#setState({ focused: false })`
-            /*
-            radio.setState({ focused: false });
-            expect(radio.find('label').hasClass('radio_focused')).to.be.false;
-            expect(radio.find('button').hasClass('button_focused')).to.be.false;
-            */
-        });
-
-        it('accepts DOM focus', () => {
-            const radio = mount(<Radio type="button">radio</Radio>);
-            const button = radio.find('button');
-
-            button.simulate('focus');
-            expect(radio.find('label').hasClass('radio_focused')).to.be.true;
-            expect(radio.find('button').hasClass('button_focused')).to.be.true;
-            expect(radio.find('button').hasClass('button_focused-hard')).to.be.true;
-
-            button.simulate('blur');
-            expect(radio.find('label').hasClass('radio_focused')).to.be.false;
-            expect(radio.find('button').hasClass('button_focused')).to.be.false;
-            expect(radio.find('button').hasClass('button_focused-hard')).to.be.false;
-        });
-
-        it('removes focused if receives disabled', () => {
-            const radio = mount(<Radio type="button" focused>radio</Radio>);
-
-            radio.setProps({ disabled: true });
-            expect(radio.find('label').hasClass('radio_focused')).to.be.false;
-            expect(radio.find('button').hasClass('button_focused')).to.be.false;
-        });
-
-        it('is hovered on mouseenter/mouseleave', () => {
-            const radio = mount(<Radio type="button">radio</Radio>);
-            const button = radio.find('button');
-
-            expect(radio.find('label').hasClass('radio_hovered')).to.be.false;
-            expect(radio.find('button').hasClass('button_hovered')).to.be.false;
-
-            button.simulate('mouseenter');
-            expect(radio.state('hovered')).to.be.true;
-            expect(radio.find('label').hasClass('radio_hovered')).to.be.true;
-            expect(radio.find('button').hasClass('button_hovered')).to.be.true;
-
-            button.simulate('mouseleave');
-            expect(radio.state('hovered')).to.be.false;
-            expect(radio.find('label').hasClass('radio_hovered')).to.be.false;
-            expect(radio.find('button').hasClass('button_hovered')).to.be.false;
-        });
-
-        it('can not be hovered if disabled', () => {
-            const radio = mount(<Radio type="button" disabled>radio</Radio>);
-            const button = radio.find('button');
-
-            button.simulate('mouseenter');
-            expect(radio.state('hovered')).to.not.be.ok;
-            expect(radio.find('label').hasClass('radio_hovered')).to.not.be.ok;
-            expect(radio.find('button').hasClass('button_hovered')).to.not.be.ok;
-        });
-
-        it('can not be checked with q', () => {
-            const spy = sinon.spy();
-            const radio = mount(<Radio type="button" focused onCheck={spy}>radio</Radio>);
-
-            expect(radio.state('checked')).to.not.be.ok;
-
-            radio.find('button').simulate('keydown', { key: 'q' });
-            radio.find('button').simulate('keyup');
-            expect(radio.state('checked')).to.not.be.ok;
-        });
-
-        it('can be checked with space if focused', () => {
-            const spy = sinon.spy();
-            const radio = mount(<Radio type="button" focused onCheck={spy}>radio</Radio>);
-
-            expect(radio.state('checked')).to.not.be.ok;
-
-            radio.find('button').simulate('keydown', { key: ' ' });
-            radio.find('button').simulate('keyup');
-            expect(radio.state('checked')).to.be.true;
-            radio.find('button').simulate('keydown', { key: ' ' });
-            radio.find('button').simulate('keyup');
-            expect(radio.state('checked')).to.be.true;
-
-            expect(spy.callCount).to.equal(1);
-            expect(spy.getCall(0).args[0]).to.be.true;
-        });
-
-        it('can be checked with enter if focused', () => {
-            const spy = sinon.spy();
-            const radio = mount(<Radio type="button" focused onCheck={spy}>radio</Radio>);
-
-            expect(radio.state('checked')).to.not.be.ok;
-
-            radio.find('button').simulate('keydown', { key: 'Enter' });
-            radio.find('button').simulate('keyup');
-            expect(radio.state('checked')).to.be.true;
-            radio.find('button').simulate('keydown', { key: 'Enter' });
-            radio.find('button').simulate('keyup');
-            expect(radio.state('checked')).to.be.true;
-
-            expect(spy.callCount).to.equal(1);
-            expect(spy.getCall(0).args[0]).to.be.true;
-        });
-
-        it('can not be checked with space if disabled', () => {
-            const spy = sinon.spy();
-            const radio = mount(<Radio type="button" disabled onCheck={spy}>radio</Radio>);
-
-            expect(radio.state('checked')).to.not.be.ok;
-
-            radio.find('button').simulate('keydown', { key: ' ' });
-            radio.find('button').simulate('keyup');
-            expect(radio.state('checked')).to.not.be.ok;
-
-            expect(spy.called).to.be.false;
-        });
-
-        it('can be checked with click', () => {
-            const spy = sinon.spy();
-            const radio = mount(<Radio type="button" onCheck={spy} name="foo">radio</Radio>);
-
-            expect(radio.state('checked')).to.not.be.ok;
-
-            radio.find('button').simulate('mousedown', { button: 0 });
-            radio.find('button').simulate('mouseup');
-            expect(radio.state('checked')).to.be.true;
-
-            radio.find('button').simulate('mousedown', { button: 0 });
-            radio.find('button').simulate('mouseup');
-            expect(radio.state('checked')).to.be.true;
-
-            expect(spy.calledOnce).to.be.true;
-            expect(spy.getCall(0).args[0]).to.be.true;
-        });
-
-        it('onCheck receive props as a second argument', () => {
-            const spy = sinon.spy();
-            const radio = mount(<Radio type="button" onCheck={spy} name="foo" bar="42">radio</Radio>);
-
-            radio.find('button').simulate('mousedown', { button: 0 });
-            radio.find('button').simulate('mouseup');
-
-            expect(spy.getCall(0).args[1].name).to.equal('foo');
-            expect(spy.getCall(0).args[1].bar).to.equal('42');
-        });
-
-        it('can not be checked with click if disabled', () => {
-            const spy = sinon.spy();
-            const radio = mount(<Radio type="button" disabled onCheck={spy}>radio</Radio>);
-
-            radio.find('button').simulate('mousedown');
-            radio.find('button').simulate('mouseup');
-            expect(radio.state('checked')).to.not.be.ok;
-
-            expect(spy.called).to.be.false;
-        });
-
-    });
-
     describe('type is not set (radio)', () => {
-
         it('is a radio', () => {
             const radio = shallow(<Radio>radio</Radio>);
 
@@ -306,13 +34,6 @@ describe('Radio', () => {
             expect(input.length).to.equal(1);
             expect(input.hasClass('radio__control')).to.be.true;
             expect(input.node.getAttribute('type')).to.equal('radio');
-        });
-
-        it('has no button', () => {
-            const radio = mount(<Radio>radio</Radio>);
-
-            const button = radio.find('button');
-            expect(button.length).to.equal(0);
         });
 
         it('has text', () => {
@@ -338,7 +59,6 @@ describe('Radio', () => {
         it('accepts value prop', () => {
             const radio = mount(<Radio value="foo">radio</Radio>);
 
-            //  FIXME: Почему тут не работает node.getAttribute('value')?
             expect(radio.find('input').node.value).to.equal('foo');
         });
 
@@ -375,12 +95,10 @@ describe('Radio', () => {
         it('accepts checked prop', () => {
             const radio = mount(<Radio checked>radio</Radio>);
 
-            expect(radio.state('checked')).to.be.true;
             expect(radio.find('label').hasClass('radio_checked')).to.be.true;
             expect(radio.find('input').node.checked).to.be.true;
 
             radio.setProps({ checked: false });
-            expect(radio.state('checked')).to.be.false;
             expect(radio.find('label').hasClass('radio_checked')).to.be.false;
             expect(radio.find('input').node.checked).to.be.false;
         });
@@ -434,103 +152,286 @@ describe('Radio', () => {
             expect(radio.find('label').hasClass('radio_hovered')).to.not.be.ok;
         });
 
-        it.skip('can not be checked with q', () => {
+        it('calls onCheck on input change', () => {
             const spy = sinon.spy();
-            const radio = mount(<Radio focused onCheck={spy}>radio</Radio>);
+            const radio = mount(<Radio checked={false} onCheck={spy} name="foo">radio</Radio>);
 
-            expect(radio.state('checked')).to.not.be.ok;
+            radio.find('input').simulate('change');
 
-            radio.find('input').simulate('keydown', { key: 'q' });
-            radio.find('input').simulate('keyup');
-            expect(radio.state('checked')).to.not.be.ok;
+            expect(spy).to.have.been.calledOnce;
+            expect(spy.lastCall).to.have.been.calledWithMatch(true, { name: 'foo' });
         });
 
-        it.skip('can be checked with space if focused', () => {
+        it('does not call onCheck if disabled', () => {
             const spy = sinon.spy();
-            const radio = mount(<Radio focused onCheck={spy}>radio</Radio>);
+            const radio = mount(<Radio onCheck={spy} disabled>radio</Radio>);
 
-            expect(radio.state('checked')).to.not.be.ok;
+            radio.find('input').simulate('change');
 
-            radio.find('input').simulate('keydown', { key: ' ' });
-            radio.find('input').simulate('keyup');
-            expect(radio.state('checked')).to.be.true;
-            radio.find('input').simulate('keydown', { key: ' ' });
-            radio.find('input').simulate('keyup');
-            expect(radio.state('checked')).to.be.true;
+            expect(spy).to.not.have.been.called;
+        });
+    });
 
-            expect(spy.callCount).to.equal(1);
-            expect(spy.getCall(0).args[0]).to.be.true;
+    describe('type="button"', () => {
+        it('is a radio', () => {
+            const radio = shallow(<Radio type="button">radio</Radio>);
+
+            expect(radio.is('.radio')).to.be.true;
         });
 
-        it.skip('can be checked with enter if focused', () => {
-            const spy = sinon.spy();
-            const radio = mount(<Radio focused onCheck={spy}>radio</Radio>);
+        it('is a button', () => {
+            const radio = mount(<Radio type="button">radio</Radio>);
 
-            expect(radio.state('checked')).to.not.be.ok;
+            const button = radio.find('button');
+            expect(button.length).to.equal(1);
+            expect(button.hasClass('button')).to.be.true;
 
-            radio.find('input').simulate('keydown', { key: 'Enter' });
-            radio.find('input').simulate('keyup');
-            expect(radio.state('checked')).to.be.true;
-            radio.find('input').simulate('keydown', { key: 'Enter' });
-            radio.find('input').simulate('keyup');
-            expect(radio.state('checked')).to.be.true;
-
-            expect(spy.callCount).to.equal(1);
-            expect(spy.getCall(0).args[0]).to.be.true;
+            const text = button.find('span');
+            expect(text.hasClass('button__text')).to.be.true;
+            expect(text.node.textContent).to.equal('radio');
         });
 
-        it.skip('can not be checked with space if disabled', () => {
-            const spy = sinon.spy();
-            const radio = mount(<Radio disabled onCheck={spy}>radio</Radio>);
+        it('has label', () => {
+            const radio = mount(<Radio type="button">radio</Radio>);
 
-            expect(radio.state('checked')).to.not.be.ok;
-
-            radio.find('input').simulate('keydown', { key: ' ' });
-            radio.find('input').simulate('keyup');
-            expect(radio.state('checked')).to.not.be.ok;
-
-            expect(spy.called).to.be.false;
+            const label = radio.find('label');
+            expect(label.length).to.equal(1);
+            expect(label.hasClass('radio')).to.be.true;
         });
 
-        it.skip('can be checked with click', () => {
-            const spy = sinon.spy();
-            const radio = mount(<Radio onCheck={spy} name="foo">radio</Radio>);
+        it('accepts type prop', () => {
+            const radio = mount(<Radio type="button"/>);
 
-            expect(radio.state('checked')).to.not.be.ok;
-
-            radio.find('input').simulate('mousedown');
-            radio.find('input').simulate('mouseup');
-            expect(radio.state('checked')).to.be.true;
-
-            radio.find('input').simulate('mousedown');
-            radio.find('input').simulate('mouseup');
-            expect(radio.state('checked')).to.be.true;
-
-            expect(spy.callCount).to.equal(1);
-            expect(spy.getCall(0).args[0]).to.be.true;
+            expect(radio.find('label').hasClass('radio_type_button')).to.be.true;
+            expect(radio.find('button').hasClass('button_type_button')).to.be.true;
         });
 
-        it.skip('onCheck receive props as a second argument', () => {
-            const spy = sinon.spy();
-            const radio = mount(<Radio onCheck={spy} name="foo" bar="42">radio</Radio>);
+        it('accepts theme prop', () => {
+            const radio = mount(<Radio type="button" theme="foo">radio</Radio>);
 
-            radio.find('input').simulate('mousedown');
-            radio.find('input').simulate('mouseup');
+            expect(radio.find('label').hasClass('radio_theme_foo')).to.be.true;
+            expect(radio.find('button').hasClass('button_theme_foo')).to.be.true;
+        });
+
+        it('accepts size prop', () => {
+            const radio = mount(<Radio type="button" size="foo">radio</Radio>);
+
+            expect(radio.find('label').hasClass('radio_size_foo')).to.be.true;
+            expect(radio.find('button').hasClass('button_size_foo')).to.be.true;
+        });
+
+        it('accepts className prop', () => {
+            const radio = shallow(<Radio type="button" className="my-radio not-my-radio">radio</Radio>);
+
+            expect(radio.hasClass('my-radio')).to.be.true;
+            expect(radio.hasClass('not-my-radio')).to.be.true;
+        });
+
+        it('accepts checked prop', () => {
+            const radio = mount(<Radio type="button" checked>radio</Radio>);
+
+            expect(radio.find('label').hasClass('radio_checked')).to.be.true;
+            expect(radio.find('button').hasClass('button_checked')).to.be.true;
+            expect(radio.find('input').length).to.equal(1);
+
+            radio.setProps({ checked: false });
+            expect(radio.find('label').hasClass('radio_checked')).to.be.false;
+            expect(radio.find('button').hasClass('button_checked')).to.be.false;
+            expect(radio.find('input').length).to.equal(0);
+        });
+
+        it('accepts value prop', () => {
+            const radio = mount(<Radio type="button" checked value="foo">radio</Radio>);
+
+            expect(radio.find('input').node.value).to.equal('foo');
+        });
+
+        it('accepts name prop', () => {
+            const radio = mount(<Radio type="button" checked name="foo">radio</Radio>);
+
+            expect(radio.find('input').node.getAttribute('name')).to.equal('foo');
+        });
+
+        it('accepts disabled prop', () => {
+            const radio = mount(<Radio type="button" checked disabled>radio</Radio>);
+
+            expect(radio.find('label').hasClass('radio_disabled')).to.be.true;
+            expect(radio.find('button').hasClass('button_disabled')).to.be.true;
+            expect(radio.find('input').node.hasAttribute('disabled')).to.be.true;
+
+            radio.setProps({ disabled: false });
+            expect(radio.find('label').hasClass('radio_disabled')).to.be.false;
+            expect(radio.find('button').hasClass('button_disabled')).to.be.false;
+            expect(radio.find('input').node.hasAttribute('disabled')).to.be.false;
+        });
+
+        it('accepts focused prop', () => {
+            const radio = mount(<Radio type="button" focused>radio</Radio>);
+
+            expect(radio.state('focused')).to.be.true;
+            expect(radio.find('label').hasClass('radio_focused')).to.be.true;
+            expect(radio.find('button').hasClass('button_focused')).to.be.true;
+
+            // FIXME(narqo@): `Control#setState({ focused: false })`
+            /*
+            radio.setState({ focused: false });
+            expect(radio.find('label').hasClass('radio_focused')).to.be.false;
+            expect(radio.find('button').hasClass('button_focused')).to.be.false;
+            */
+        });
+
+        it('reacts on DOM focus', () => {
+            const radio = mount(<Radio type="button">radio</Radio>);
+            const button = radio.find('button');
+
+            button.simulate('focus');
+            expect(radio.find('label').hasClass('radio_focused')).to.be.true;
+            expect(radio.find('button').hasClass('button_focused')).to.be.true;
+            expect(radio.find('button').hasClass('button_focused-hard')).to.be.true;
+
+            button.simulate('blur');
+            expect(radio.find('label').hasClass('radio_focused')).to.be.false;
+            expect(radio.find('button').hasClass('button_focused')).to.be.false;
+            expect(radio.find('button').hasClass('button_focused-hard')).to.be.false;
+        });
+
+        it('removes focused if receives disabled', () => {
+            const radio = mount(<Radio type="button" focused>radio</Radio>);
+
+            radio.setProps({ disabled: true });
+            expect(radio.find('label').hasClass('radio_focused')).to.be.false;
+            expect(radio.find('button').hasClass('button_focused')).to.be.false;
+        });
+
+        it('is hovered on mouseenter/mouseleave', () => {
+            const radio = mount(<Radio type="button">radio</Radio>);
+            const button = radio.find('button');
+
+            expect(radio.find('label').hasClass('radio_hovered')).to.be.false;
+            expect(radio.find('button').hasClass('button_hovered')).to.be.false;
+
+            button.simulate('mouseenter');
+            expect(radio.state('hovered')).to.be.true;
+            expect(radio.find('label').hasClass('radio_hovered')).to.be.true;
+            expect(radio.find('button').hasClass('button_hovered')).to.be.true;
+
+            button.simulate('mouseleave');
+            expect(radio.state('hovered')).to.be.false;
+            expect(radio.find('label').hasClass('radio_hovered')).to.be.false;
+            expect(radio.find('button').hasClass('button_hovered')).to.be.false;
+        });
+
+        it('can not be hovered if disabled', () => {
+            const radio = mount(<Radio type="button" disabled>radio</Radio>);
+            const button = radio.find('button');
+
+            button.simulate('mouseenter');
+            expect(radio.state('hovered')).to.not.be.ok;
+            expect(radio.find('label').hasClass('radio_hovered')).to.not.be.ok;
+            expect(radio.find('button').hasClass('button_hovered')).to.not.be.ok;
+        });
+
+        it('calls onCheck handler on space press if focused', () => {
+            const spy = sinon.spy();
+            const radio = mount(<Radio type="button" focused onCheck={spy}>text</Radio>);
+            const button = radio.find('button');
+
+            button.simulate('keydown', { key: ' ' });
+            button.simulate('keyup');
+            expect(spy.calledOnce).to.be.true;
+            expect(spy.lastCall).to.have.been.calledWith(true);
+
+            radio.setProps({ checked: true });
+
+            button.simulate('keydown', { key: ' ' });
+            button.simulate('keyup');
+
+            expect(spy).to.have.been.calledOnce;
+        });
+
+        it('calls onCheck handler on enter press if focused', () => {
+            const spy = sinon.spy();
+            const radio = mount(<Radio type="button" focused onCheck={spy}>text</Radio>);
+            const button = radio.find('button');
+
+            button.simulate('keydown', { key: 'Enter' });
+            button.simulate('keyup');
+            expect(spy.calledOnce).to.be.true;
+            expect(spy.lastCall).to.have.been.calledWith(true);
+
+            radio.setProps({ checked: true });
+
+            button.simulate('keydown', { key: 'Enter' });
+            button.simulate('keyup');
+
+            expect(spy).to.have.been.calledOnce;
+        });
+
+        it('does not call onCheck on space / enter press if disabled', () => {
+            const spy = sinon.spy();
+            const radio = mount(<Radio type="button" focused disabled onCheck={spy}>text</Radio>);
+            const button = radio.find('button');
+
+            button.simulate('keydown', { key: ' ' });
+            button.simulate('keyup');
+            expect(spy).to.not.have.been.called;
+
+            button.simulate('keydown', { key: 'Enter' });
+            button.simulate('keyup');
+            expect(spy).to.not.have.been.called;
+        });
+
+        it('calls onClick on button click', () => {
+            const spy = sinon.spy();
+            const radio = mount(<Radio type="button" onCheck={spy} name="foo">text</Radio>);
+            const button = radio.find('button');
+
+            button.simulate('mousedown', { button: 0 });
+            button.simulate('mouseup');
+            expect(spy).to.have.been.calledOnce;
+            expect(spy.lastCall).to.have.been.calledWith(true);
+
+            radio.setProps({ checked: true });
+
+            button.simulate('mousedown', { button: 0 });
+            button.simulate('mouseup');
+
+            expect(spy).to.have.been.calledOnce;
+        });
+
+        it('does not call onCheck if onClick default prevented', () => {
+            const spy = sinon.spy();
+            const onClick = e => e.preventDefault();
+            const radio = mount(<Radio type="button" onClick={onClick} onCheck={spy} name="foo">text</Radio>);
+            const button = radio.find('button');
+
+            button.simulate('mousedown', { button: 0 });
+            button.simulate('mouseup');
+
+            expect(spy).to.not.have.been.called;
+        });
+
+        it('passes props to onCheck as a second argument', () => {
+            const spy = sinon.spy();
+            const radio = mount(<Radio type="button" onCheck={spy} name="foo" bar="42">text</Radio>);
+            const button = radio.find('button');
+
+            button.simulate('mousedown', { button: 0 });
+            button.simulate('mouseup');
 
             expect(spy.getCall(0).args[1].name).to.equal('foo');
             expect(spy.getCall(0).args[1].bar).to.equal('42');
         });
 
-        it.skip('can not be checked with click if disabled', () => {
+        it('does not call onCheck on button click if disabled', () => {
             const spy = sinon.spy();
-            const radio = mount(<Radio disabled onCheck={spy}>radio</Radio>);
+            const radio = mount(<Radio type="button" disabled onCheck={spy}>text</Radio>);
+            const button = radio.find('button');
 
-            radio.find('input').simulate('mousedown');
-            radio.find('input').simulate('mouseup');
-            expect(radio.state('checked')).to.not.be.ok;
+            button.simulate('mousedown', { button: 0 });
+            button.simulate('mouseup');
 
-            expect(spy.called).to.be.false;
+            expect(spy).to.not.have.been.called;
         });
-
     });
 });

--- a/src/RadioGroup/examples.js
+++ b/src/RadioGroup/examples.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import App from '../App';
-import RadioGroup from './index.js';
+import RadioGroup from './';
 import Radio from '../Radio';
 
 class Example extends React.Component {
@@ -35,7 +35,7 @@ class Example extends React.Component {
                     </div>
 
                     <div className="example">
-                        <RadioGroup size="l" type="button" name="b" onChange={this.onChange}>
+                        <RadioGroup size="m" type="button" name="b" value={this.state.b} onChange={this.onChange}>
                             <Radio value="10">10</Radio>
                             <Radio value="20">20</Radio>
                             <Radio value="30">30</Radio>
@@ -57,7 +57,7 @@ class Example extends React.Component {
                     </div>
 
                     <div className="example">
-                        <RadioGroup size="l" type="line" name="d" onChange={this.onChange}>
+                        <RadioGroup size="m" type="line" name="d" value={this.state.d} onChange={this.onChange}>
                             <Radio value="10">10</Radio>
                             <Radio value="20">20</Radio>
                             <Radio value="30">30</Radio>
@@ -65,6 +65,26 @@ class Example extends React.Component {
                             <Radio value="50">50</Radio>
                         </RadioGroup>
                         <div>Selected: {this.state.d}</div>
+                    </div>
+
+                    <div className="example">
+                        <RadioGroup size="l" type="button" name="e" disabled>
+                            <Radio value="10">10</Radio>
+                            <Radio value="20">20</Radio>
+                            <Radio value="30">30</Radio>
+                            <Radio value="40" disabled>40</Radio>
+                            <Radio value="50">50</Radio>
+                        </RadioGroup>
+                    </div>
+
+                    <div className="example">
+                        <RadioGroup size="l" type="line" name="f" disabled>
+                            <Radio value="10">10</Radio>
+                            <Radio value="20">20</Radio>
+                            <Radio value="30">30</Radio>
+                            <Radio value="40" disabled>40</Radio>
+                            <Radio value="50">50</Radio>
+                        </RadioGroup>
                     </div>
 
                 </div>

--- a/src/RadioGroup/index.js
+++ b/src/RadioGroup/index.js
@@ -1,34 +1,15 @@
 import React from 'react';
-
 import Component from '../Component';
 
 class RadioGroup extends Component {
     constructor(props) {
         super(props);
 
-        this.state = {
-            value: props.value,
-        };
-
-        this.onRadioCheck = this.onRadioCheck.bind(this);
-    }
-
-    componentWillReceiveProps(props) {
-        //  FIXME: А нужно ли вообще перевыставлять value в стейт?
-        //  Ведь то, что в RadioGroup задается — это начальное значение,
-        //  дальше оно меняется в собственном стейте.
-        if (props.value !== this.props.value) {
-            this.setState({
-                ...this.state,
-                value: props.value,
-            });
-        }
+        this.onChildCheck = this.onChildCheck.bind(this);
     }
 
     render() {
-        const onRadioCheck = this.onRadioCheck;
-        const { value } = this.state;
-        const { theme, size, type, name, disabled } = this.props;
+        const { theme, size, type, name, disabled, value } = this.props;
 
         const children = React.Children.map(this.props.children, child => {
             const checked = child.props.value === value;
@@ -41,7 +22,7 @@ class RadioGroup extends Component {
                 disabled,
                 ...child.props,
                 checked,
-                onCheck: onRadioCheck,
+                onCheck: this.onChildCheck,
             });
         });
 
@@ -53,7 +34,7 @@ class RadioGroup extends Component {
     }
 
     className() {
-        var className = 'radio-group control-group';
+        let className = 'radio-group control-group';
 
         const theme = this.props.theme || this.context.theme;
         if (theme) {
@@ -73,17 +54,16 @@ class RadioGroup extends Component {
         return className;
     }
 
-    onRadioCheck(checked, radioProps) {
+    onChildCheck(_, radioProps) {
         const value = radioProps.value;
-        if (value !== this.state.value) {
-            this.setState({ value });
+        if (value !== this.props.value) {
             this.props.onChange(value, this.props);
         }
     }
 }
 
-RadioGroup.defaultProps = {
-    onChange() {},
+RadioGroup.contextTypes = {
+    theme: React.PropTypes.string,
 };
 
 RadioGroup.propTypes = {
@@ -92,11 +72,12 @@ RadioGroup.propTypes = {
     type: React.PropTypes.string,
     name: React.PropTypes.string,
     value: React.PropTypes.any,
+    disabled: React.PropTypes.bool,
     onChange: React.PropTypes.func,
 };
 
-RadioGroup.contextTypes = {
-    theme: React.PropTypes.string,
+RadioGroup.defaultProps = {
+    onChange() {},
 };
 
 module.exports = RadioGroup;

--- a/src/RadioGroup/test.js
+++ b/src/RadioGroup/test.js
@@ -1,180 +1,19 @@
 /* eslint-env mocha */
 
 import React from 'react';
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
 import { shallow, mount } from 'enzyme';
+import chaiEnzyme from 'chai-enzyme';
 import sinon from 'sinon';
-
+import sinonChai from 'sinon-chai';
 import RadioGroup from './';
 import Radio from '../Radio';
 
+chai.use(sinonChai);
+chai.use(chaiEnzyme());
+
 describe('RadioGroup', () => {
-
-    describe('type="button"', () => {
-
-        it('is a radio-group', () => {
-            const group = shallow(
-                <RadioGroup type="radio"/>
-            );
-
-            expect(group.is('.radio-group')).to.be.true;
-        });
-
-        it('has radios', () => {
-            const group = mount(
-                <RadioGroup type="button">
-                    <Radio value="10">10</Radio>
-                    <Radio value="20">20</Radio>
-                    <Radio value="30">30</Radio>
-                </RadioGroup>
-            );
-
-            const radios = group.find('.radio');
-            expect(radios.length).to.equal(3);
-        });
-
-        it('accepts className prop', () => {
-            const group = shallow(
-                <RadioGroup type="button" className="my-radio-group not-my-radio-group"/>
-            );
-
-            expect(group.hasClass('my-radio-group')).to.be.true;
-            expect(group.hasClass('not-my-radio-group')).to.be.true;
-        });
-
-        it('accepts type prop', () => {
-            const wrapper = mount(
-                <RadioGroup type="button">
-                    <Radio value="10">10</Radio>
-                </RadioGroup>
-            );
-            const group = wrapper.find('.radio-group');
-
-            expect(group.hasClass('radio-group_type_button')).to.be.true;
-
-            const radio = group.find('.radio');
-            expect(radio.hasClass('radio_type_button')).to.be.true;
-        });
-
-        it('accepts theme prop', () => {
-            const wrapper = mount(
-                <RadioGroup type="button" theme="foo">
-                    <Radio value="10">10</Radio>
-                </RadioGroup>
-            );
-            const group = wrapper.find('.radio-group');
-
-            expect(group.hasClass('radio-group_theme_foo')).to.be.true;
-
-            const radio = group.find('.radio');
-            expect(radio.hasClass('radio_theme_foo')).to.be.true;
-        });
-
-        it('accepts size prop', () => {
-            const wrapper = mount(
-                <RadioGroup type="button" size="m">
-                    <Radio value="10">10</Radio>
-                </RadioGroup>
-            );
-            const group = wrapper.find('.radio-group');
-
-            expect(group.hasClass('radio-group_size_m')).to.be.true;
-
-            const radio = group.find('.radio');
-            expect(radio.hasClass('radio_size_m')).to.be.true;
-        });
-
-        it('accepts name prop', () => {
-            const wrapper = mount(
-                <RadioGroup type="button" name="foo">
-                    <Radio value="10">10</Radio>
-                </RadioGroup>
-            );
-            const group = wrapper.find('.radio-group');
-
-            const radio = group.find('.radio');
-            //  Не получится тут тестить `radio.prop('name')`.
-            //  Придется лезть в DOM руками.
-            expect(radio.find('input').node.getAttribute('name')).to.equal('foo');
-        });
-
-        it('accepts value prop', () => {
-            const wrapper = mount(
-                <RadioGroup type="button" value="10">
-                    <Radio value="10">10</Radio>
-                    <Radio value="20">20</Radio>
-                    <Radio value="30">30</Radio>
-                </RadioGroup>
-            );
-            const group = wrapper.find('.radio-group');
-
-            const radioes = group.find('.radio');
-            expect(radioes.at(0).hasClass('radio_checked')).to.be.true;
-            expect(radioes.at(1).hasClass('radio_checked')).to.be.false;
-            expect(radioes.at(2).hasClass('radio_checked')).to.be.false;
-        });
-
-        it('can change value via setState', () => {
-            const wrapper = mount(
-                <RadioGroup type="button" value="10">
-                    <Radio value="10">10</Radio>
-                    <Radio value="20">20</Radio>
-                    <Radio value="30">30</Radio>
-                </RadioGroup>
-            );
-            const group = wrapper.find('.radio-group');
-
-            wrapper.setState({ value: '20' });
-
-            const radioes = group.find('.radio');
-            expect(radioes.at(0).hasClass('radio_checked')).to.be.false;
-            expect(radioes.at(1).hasClass('radio_checked')).to.be.true;
-            expect(radioes.at(2).hasClass('radio_checked')).to.be.false;
-        });
-
-        it('accepts disabled prop', () => {
-            const wrapper = mount(
-                <RadioGroup type="button" disabled>
-                    <Radio value="10">10</Radio>
-                </RadioGroup>
-            );
-            const group = wrapper.find('.radio-group');
-
-            const radio = group.find('.radio');
-            expect(radio.hasClass('radio_disabled')).to.be.true;
-
-            wrapper.setProps({ disabled: false });
-            expect(radio.hasClass('radio_disabled')).to.be.false;
-        });
-
-        it('change value if radio clicked', () => {
-            const spy = sinon.spy();
-            const wrapper = mount(
-                <RadioGroup type="button" value="10" onChange={spy} foo="bar">
-                    <Radio value="10">10</Radio>
-                    <Radio value="20">20</Radio>
-                    <Radio value="30">30</Radio>
-                </RadioGroup>
-            );
-            const group = wrapper.find('.radio-group');
-
-            const secondRadioButton = group
-                .find('.radio')
-                .at(1)
-                .find('button');
-            secondRadioButton.simulate('mousedown', { button: 0 });
-            secondRadioButton.simulate('mouseup');
-
-            expect(wrapper.state('value')).to.equal('20');
-
-            expect(spy.callCount).to.equal(1);
-            expect(spy.getCall(0).args[1].foo).to.equal('bar');
-        });
-
-    });
-
     describe('type="line"', () => {
-
         it('is a radio-group', () => {
             const group = shallow(
                 <RadioGroup type="radio"/>
@@ -253,31 +92,26 @@ describe('RadioGroup', () => {
                     <Radio value="10">10</Radio>
                 </RadioGroup>
             );
-            const group = wrapper.find('.radio-group');
-
-            const radio = group.find('.radio');
-            //  Не получится тут тестить `radio.prop('name')`.
-            //  Придется лезть в DOM руками.
-            expect(radio.find('input').node.getAttribute('name')).to.equal('foo');
+            const radio = wrapper.find('.radio-group').find(Radio);
+            expect(radio).to.have.prop('name', 'foo');
         });
 
         it('accepts value prop', () => {
             const wrapper = mount(
-                <RadioGroup type="line" value="10">
+                <RadioGroup type="line" value="30">
                     <Radio value="10">10</Radio>
                     <Radio value="20">20</Radio>
                     <Radio value="30">30</Radio>
                 </RadioGroup>
             );
-            const group = wrapper.find('.radio-group');
+            const radios = wrapper.find('.radio-group').find(Radio);
 
-            const radioes = group.find('.radio');
-            expect(radioes.at(0).hasClass('radio_checked')).to.be.true;
-            expect(radioes.at(1).hasClass('radio_checked')).to.be.false;
-            expect(radioes.at(2).hasClass('radio_checked')).to.be.false;
+            expect(radios.at(0)).to.not.have.prop('checked', true);
+            expect(radios.at(1)).to.not.have.prop('checked', true);
+            expect(radios.at(2)).to.have.prop('checked', true);
         });
 
-        it('can change value via setState', () => {
+        it('updates children on value change', () => {
             const wrapper = mount(
                 <RadioGroup type="line" value="10">
                     <Radio value="10">10</Radio>
@@ -285,14 +119,13 @@ describe('RadioGroup', () => {
                     <Radio value="30">30</Radio>
                 </RadioGroup>
             );
-            const group = wrapper.find('.radio-group');
 
-            wrapper.setState({ value: '20' });
+            wrapper.setProps({ value: '20' });
 
-            const radioes = group.find('.radio');
-            expect(radioes.at(0).hasClass('radio_checked')).to.be.false;
-            expect(radioes.at(1).hasClass('radio_checked')).to.be.true;
-            expect(radioes.at(2).hasClass('radio_checked')).to.be.false;
+            const radios = wrapper.find('.radio-group').find(Radio);
+            expect(radios.at(0)).to.not.have.prop('checked', true);
+            expect(radios.at(1)).to.have.prop('checked', true);
+            expect(radios.at(2)).to.not.have.prop('checked', true);
         });
 
         it('accepts disabled prop', () => {
@@ -301,17 +134,15 @@ describe('RadioGroup', () => {
                     <Radio value="10">10</Radio>
                 </RadioGroup>
             );
-            const group = wrapper.find('.radio-group');
-
-            const radio = group.find('.radio');
-            expect(radio.hasClass('radio_disabled')).to.be.true;
+            const radio = wrapper.find('.radio-group').find(Radio);
+            expect(radio).to.have.prop('disabled', true);
 
             wrapper.setProps({ disabled: false });
-            expect(radio.hasClass('radio_disabled')).to.be.false;
+
+            expect(radio).to.not.have.prop('disabled', true);
         });
 
-        //  FIXME: Не получается правильно сэмулировать клик в чекбокс.
-        it.skip('change value if radio clicked', () => {
+        it('calls onChange handler on Radio change', () => {
             const spy = sinon.spy();
             const wrapper = mount(
                 <RadioGroup type="line" value="10" onChange={spy} foo="bar">
@@ -320,20 +151,165 @@ describe('RadioGroup', () => {
                     <Radio value="30">30</Radio>
                 </RadioGroup>
             );
+            const radio2 = wrapper.find(Radio)
+                .at(1)
+                .find('input');
+
+            radio2.simulate('change');
+
+            expect(spy).to.have.been.calledOnce;
+            expect(spy.lastCall.args[0]).to.equal('20');
+            expect(spy.lastCall.args[1].foo).to.equal('bar');
+        });
+    });
+
+    describe('type="button"', () => {
+        it('is a radio-group', () => {
+            const group = shallow(
+                <RadioGroup type="radio"/>
+            );
+
+            expect(group.is('.radio-group')).to.be.true;
+        });
+
+        it('has radios', () => {
+            const group = mount(
+                <RadioGroup type="button">
+                    <Radio value="10">10</Radio>
+                    <Radio value="20">20</Radio>
+                    <Radio value="30">30</Radio>
+                </RadioGroup>
+            );
+
+            const radios = group.find('.radio');
+            expect(radios.length).to.equal(3);
+        });
+
+        it('accepts className prop', () => {
+            const group = shallow(
+                <RadioGroup type="button" className="my-radio-group not-my-radio-group"/>
+            );
+
+            expect(group.hasClass('my-radio-group')).to.be.true;
+            expect(group.hasClass('not-my-radio-group')).to.be.true;
+        });
+
+        it('accepts type prop', () => {
+            const wrapper = mount(
+                <RadioGroup type="button">
+                    <Radio value="10">10</Radio>
+                </RadioGroup>
+            );
             const group = wrapper.find('.radio-group');
 
-            const secondRadioButton = group
-                .find('.radio')
+            expect(group.hasClass('radio-group_type_button')).to.be.true;
+
+            const radio = group.find('.radio');
+            expect(radio.hasClass('radio_type_button')).to.be.true;
+        });
+
+        it('accepts theme prop', () => {
+            const wrapper = mount(
+                <RadioGroup type="button" theme="foo">
+                    <Radio value="10">10</Radio>
+                </RadioGroup>
+            );
+            const group = wrapper.find('.radio-group');
+
+            expect(group.hasClass('radio-group_theme_foo')).to.be.true;
+
+            const radio = group.find('.radio');
+            expect(radio.hasClass('radio_theme_foo')).to.be.true;
+        });
+
+        it('accepts size prop', () => {
+            const wrapper = mount(
+                <RadioGroup type="button" size="m">
+                    <Radio value="10">10</Radio>
+                </RadioGroup>
+            );
+            const group = wrapper.find('.radio-group');
+
+            expect(group.hasClass('radio-group_size_m')).to.be.true;
+
+            const radio = group.find('.radio');
+            expect(radio.hasClass('radio_size_m')).to.be.true;
+        });
+
+        it('accepts name prop', () => {
+            const wrapper = mount(
+                <RadioGroup type="button" name="foo">
+                    <Radio value="10">10</Radio>
+                </RadioGroup>
+            );
+            const radio = wrapper.find('.radio-group').find(Radio);
+            expect(radio).to.have.prop('name', 'foo');
+        });
+
+        it('accepts value prop', () => {
+            const wrapper = mount(
+                <RadioGroup type="button" value="30">
+                    <Radio value="10">10</Radio>
+                    <Radio value="20">20</Radio>
+                    <Radio value="30">30</Radio>
+                </RadioGroup>
+            );
+
+            const radios = wrapper.find('.radio-group').find(Radio);
+            expect(radios.at(0)).to.not.have.prop('checked', true);
+            expect(radios.at(1)).to.not.have.prop('checked', true);
+            expect(radios.at(2)).to.have.prop('checked', true);
+        });
+
+        it('updates children on value change', () => {
+            const wrapper = mount(
+                <RadioGroup type="button" value="10">
+                    <Radio value="10">10</Radio>
+                    <Radio value="20">20</Radio>
+                    <Radio value="30">30</Radio>
+                </RadioGroup>
+            );
+
+            wrapper.setProps({ value: '20' });
+
+            const radios = wrapper.find('.radio-group').find(Radio);
+            expect(radios.at(0)).to.not.have.prop('checked', true);
+            expect(radios.at(1)).to.have.prop('checked', true);
+            expect(radios.at(2)).to.not.have.prop('checked', true);
+        });
+
+        it('accepts disabled prop', () => {
+            const wrapper = mount(
+                <RadioGroup type="button" disabled>
+                    <Radio value="10">10</Radio>
+                </RadioGroup>
+            );
+            const radio = wrapper.find('.radio-group').find(Radio);
+            expect(radio).to.have.prop('disabled', true);
+
+            wrapper.setProps({ disabled: false });
+            expect(radio).to.not.have.prop('disabled', true);
+        });
+
+        it('change value if Radio clicked', () => {
+            const spy = sinon.spy();
+            const wrapper = mount(
+                <RadioGroup type="button" value="10" onChange={spy} foo="bar">
+                    <Radio value="10">10</Radio>
+                    <Radio value="20">20</Radio>
+                    <Radio value="30">30</Radio>
+                </RadioGroup>
+            );
+            const secondRadioButton = wrapper.find(Radio)
                 .at(1)
                 .find('button');
+
             secondRadioButton.simulate('mousedown', { button: 0 });
             secondRadioButton.simulate('mouseup');
 
-            expect(wrapper.state('value')).to.equal('20');
-
-            expect(spy.callCount).to.equal(1);
-            expect(spy.getCall(0).args[1].foo).to.equal('bar');
+            expect(spy).to.have.been.calledOnce;
+            expect(spy.lastCall.args[0]).to.equal('20');
+            expect(spy.lastCall.args[1].foo).to.equal('bar');
         });
-
     });
 });


### PR DESCRIPTION
- get rid of components own states
- get rid of internal <input type=radio> in Radio(type=button)
- update chai-enzyme
- add sinon-chai
- fix tests
- add example for `Radio`

Relates to #63
