### PR TITLE
Add autocomplete="off"

### DIFF
--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -33,7 +33,7 @@ class TextInput extends Control {
                         type={this.props.type}
                         disabled={this.props.disabled}
                         placeholder={this.props.placeholder}
-                        autoComplete="off"
+                        autoComplete={this.props.autocomplete}
                         value={value}
                         onChange={this.onInputChange}
                     />
@@ -104,6 +104,7 @@ TextInput.propTypes = {
     name: React.PropTypes.string,
     value: React.PropTypes.string,
     placeholder: React.PropTypes.string,
+    autocomplete: React.PropTypes.string,
     disabled: React.PropTypes.bool,
     hasClear: React.PropTypes.bool,
     onChange: React.PropTypes.func,

--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -33,6 +33,7 @@ class TextInput extends Control {
                         type={this.props.type}
                         disabled={this.props.disabled}
                         placeholder={this.props.placeholder}
+                        autoComplete="off"
                         value={value}
                         onChange={this.onInputChange}
                     />


### PR DESCRIPTION
Is it ok to set `autocomplete="off"` by default?
Or maybe it's better to pass it via `props`?
