### PR TITLE
Revert "Popup: reposition when parent scrolls"

### DIFF
--- a/src/Popup/examples.js
+++ b/src/Popup/examples.js
@@ -110,83 +110,12 @@ class PopupExampleNested extends React.Component {
     }
 }
 
-class PopupExampleScroll extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            popup1Visible: false,
-            popup2Visible: false,
-        };
-    }
-
-    render() {
-        return (
-            <div className="example">
-                <Button
-                    ref="popup1Anchor"
-                    theme="islands"
-                    size="s"
-                    onClick={() => this.onPopup1AnchorClick()}
-                >
-                    Toggle popup 3
-                </Button>
-                <Popup
-                    theme="islands"
-                    anchor={this.refs.popup1Anchor}
-                    visible={this.state.popup1Visible}
-                    onRequestHide={() => this.onPopup1RequestHide()}
-                >
-                    <div style={{ maxHeight: 200, width: 300, overflow: 'auto' }}>
-                        <div style={{ height: 400 }}>
-                            <p>Blah-blah-blah</p>
-                            <Button
-                                ref="popup2Anchor"
-                                theme="islands"
-                                size="s"
-                                onClick={() => this.onPopup2AnchorClick()}
-                            >
-                                Toggle popup
-                            </Button>
-                            <Popup
-                                theme="islands"
-                                anchor={this.refs.popup2Anchor}
-                                visible={this.state.popup2Visible}
-                                onRequestHide={() => this.onPopup2RequestHide()}
-                            >
-                                <p>Blah-blah-blah</p>
-                            </Popup>
-                        </div>
-                    </div>
-                </Popup>
-            </div>
-        );
-    }
-
-    onPopup1AnchorClick() {
-        this.setState({ popup1Visible: !this.state.popup1Visible });
-    }
-
-    onPopup1RequestHide() {
-        this.setState({ popup1Visible: false });
-    }
-
-    onPopup2AnchorClick() {
-        this.setState({ popup2Visible: !this.state.popup2Visible });
-    }
-
-    onPopup2RequestHide() {
-        this.setState({ popup2Visible: false });
-    }
-}
-
 function Example() {
     return (
         <div className="examples">
             <PopupExampleSimple />
 
             <PopupExampleNested />
-
-            <PopupExampleScroll />
         </div>
     );
 }

--- a/src/Popup/index.js
+++ b/src/Popup/index.js
@@ -27,21 +27,16 @@ class Popup extends Component {
         };
 
         this.shouldRenderToOverlay = false;
-        this.isAnchorVisible = undefined;
-        this.scrollParents = null;
 
         this.onLayerOrderChange = this.onLayerOrderChange.bind(this);
         this.onLayerRequestHide = this.onLayerRequestHide.bind(this);
         this.onViewportResize = this.onViewportResize.bind(this);
-        this.onAnchorParentsScroll = this.onAnchorParentsScroll.bind(this);
+        this.onViewportScroll = this.onViewportScroll.bind(this);
     }
 
     componentWillUpdate(nextProps) {
         if (!this.shouldRenderToOverlay && nextProps.visible) {
             this.shouldRenderToOverlay = true;
-        }
-        if (this.props.visible && this.isAnchorVisible === undefined) {
-            this.isAnchorVisible = true;
         }
     }
 
@@ -62,7 +57,6 @@ class Popup extends Component {
                 left: this.state.left,
                 top: this.state.top,
                 zIndex: this.state.zIndex,
-                display: this.isAnchorVisible ? '' : 'none',
             };
 
             return (
@@ -110,19 +104,13 @@ class Popup extends Component {
     }
 
     handleVisibleChange(visible) {
-        this.scrollParents = getScrollParents(this.getAnchor());
-
-        if (visible) {
-            this.scrollParents.forEach(parent => {
-                parent.addEventListener('scroll', this.onAnchorParentsScroll);
-            });
+        // NOTE(@narqo): subscribe to resize/scroll only if popup can be repositioned within `directions`
+        if (visible && this.props.directions.length > 1) {
             window.addEventListener('resize', this.onViewportResize);
+            window.addEventListener('scroll', this.onViewportScroll);
         } else {
-            this.isAnchorVisible = undefined;
-            this.scrollParents.forEach(parent => {
-                parent.removeEventListener('scroll', this.onAnchorParentsScroll);
-            });
             window.removeEventListener('resize', this.onViewportResize);
+            window.removeEventListener('scroll', this.onViewportScroll);
         }
     }
 
@@ -146,13 +134,7 @@ class Popup extends Component {
         this.reposition();
     }
 
-    onAnchorParentsScroll() {
-        const isAnchorVisible = this.calcIsAnchorVisible();
-
-        if (isAnchorVisible !== this.isAnchorVisible) {
-            this.isAnchorVisible = isAnchorVisible;
-        }
-
+    onViewportScroll() {
         this.reposition();
     }
 
@@ -166,6 +148,7 @@ class Popup extends Component {
             }
 
             const { direction, left, top } = layout;
+
             this.setState({ direction, left, top });
         }
     }
@@ -330,45 +313,6 @@ class Popup extends Component {
 
         return { top, left, bottom, right };
     }
-
-    calcIsAnchorVisible() {
-        const anchor = this.calcAnchorDimensions();
-        const { direction } = this.state;
-        const vertBorder = Math.floor(
-            checkMainDirection(direction, 'top') || checkSecondaryDirection(direction, 'top') ? anchor.top : anchor.top + anchor.height
-        );
-        const horizBorder = Math.floor(
-            checkMainDirection(direction, 'left') || checkSecondaryDirection(direction, 'left') ? anchor.left : anchor.left + anchor.width
-        );
-
-        return !this.scrollParents.some(parent => {
-            if (parent === window) {
-                return false;
-            }
-
-            const { overflowX, overflowY } = window.getComputedStyle(parent);
-            const checkOverflowY = overflowY === 'scroll' || overflowY === 'hidden' || overflowY === 'auto';
-            const checkOverflowX = overflowX === 'scroll' || overflowX === 'hidden' || overflowX === 'auto';
-
-            if (checkOverflowY || checkOverflowX) {
-                const parentRect = parent.getBoundingClientRect();
-                const viewportRect = document.documentElement.getBoundingClientRect();
-                const left = Math.floor(parentRect.left - viewportRect.left);
-                const top = Math.floor(parentRect.top - viewportRect.top);
-                const { width, height } = parentRect;
-
-                if (checkOverflowY) {
-                    return vertBorder < top || top + height < vertBorder;
-                }
-
-                if (checkOverflowX) {
-                    return horizBorder < left || left + width < horizBorder;
-                }
-            }
-
-            return false;
-        });
-    }
 }
 
 function checkMainDirection(direction, mainDirection1, mainDirection2) {
@@ -377,39 +321,6 @@ function checkMainDirection(direction, mainDirection1, mainDirection2) {
 
 function checkSecondaryDirection(direction, secondaryDirection) {
     return ~direction.indexOf('-' + secondaryDirection);
-}
-
-function getScrollParents(el) {
-    if (!(el instanceof Element)) {
-        return [window];
-    }
-
-    const { position } = window.getComputedStyle(el) || {};
-    const parents = [];
-
-    if (position === 'fixed') {
-        return [el];
-    }
-
-    let parent = el;
-    while ((parent = parent.parentNode) && parent.nodeType === 1) {
-        const style = window.getComputedStyle(parent);
-
-        if (typeof style === 'undefined' || style === null) {
-            parents.push(parent);
-            return parents;
-        }
-
-        if (/(auto|scroll)/.test(style.overflow + style.overflowY + style.overflowX)) {
-            if (position !== 'absolute' || ['relative', 'absolute', 'fixed'].indexOf(style.position) >= 0) {
-                parents.push(parent)
-            }
-        }
-    }
-
-    parents.push(window);
-
-    return parents;
 }
 
 Popup.propsTypes = {


### PR DESCRIPTION
Reverts narqo/react-islands#106

Turned out those changes break the `Select` (see cases in `Select/examples.js` for #65)
