### PR TITLE
Select: get back ref name of the button

### DIFF
--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -98,7 +98,7 @@ class Select extends Component {
 
         return (
             <Button
-                ref="control"
+                ref="button"
                 theme={theme}
                 size={size}
                 className="select__button"
@@ -201,7 +201,7 @@ class Select extends Component {
     }
 
     getControl() {
-        return this.refs.control;
+        return this.refs.button;
     }
 
     getMenu() {


### PR DESCRIPTION
The changes were introduced in 6eebce453f4a5c2b74ef5ae6f7b3688618de6498 and have broken `renderButton` overrides in derived components.

/cc @fresk-nc 
